### PR TITLE
Fix missing include iomanip

### DIFF
--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -2,6 +2,7 @@
 #define __REACTION_HH__
 
 #include <iostream>
+#include <iomanip>
 #include <vector>
 #include <string>
 #include <map>


### PR DESCRIPTION
@lpgaff : quick fix, code needs iomanip header to compile

iomanip include is missing for std::setprecision in Reaction.cc