### PR TITLE
Fix bug #26 reported by Andreas Ceulemans

### DIFF
--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -437,7 +437,7 @@ unsigned long ISSEventBuilder::BuildEvents() {
 	// Apply time-walk correction, i.e. get new time ordering
 	//std::cout << " Event Building: applying time walk-correction to event ordering" << std::endl;
 	//input_tree->BuildIndex( "GetTimeWithWalk()" );
-	input_tree->BuildIndex( "GetTimeStamp()" );
+	input_tree->BuildIndex( "GetTimeMSB()", "GetTimeLSB()" );
 	TTreeIndex *att_index = (TTreeIndex*)input_tree->GetTreeIndex();
 
 	(void) att_index; // Avoid unused variable warning.

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -12,20 +12,20 @@ ClassImp( ISSReaction )
 /// \param[in] params Various parameters required for this minimisation
 /// \returns root This number should be zero when minimised
 double alpha_function( double *x, double *params ){
-
+	
 	// Equation to solve for alpha, LHS = 0
 	double alpha = x[0];
 	double z = params[0];
 	double r_meas = params[1];
 	double p = params[2];	//  p
 	double qb = params[3];	//  qb / 2*pi
-
+	
 	double root = p * TMath::Sin(alpha);
 	root -= qb * r_meas * TMath::Tan(alpha);
 	root -= qb * z;
-
+	
 	return root;
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -34,19 +34,19 @@ double alpha_function( double *x, double *params ){
 /// \param[in] params Various parameters required for this minimisation
 /// \returns root The derivative of the minimisation function
 double alpha_derivative( double *x, double *params ){
-
+	
 	// Derivative of the alpha equation
 	double alpha = x[0];
 	//double z = params[0]; // unused in derivative
 	double r_meas = params[1];
 	double p = params[2];	//  p
 	double qb = params[3];	//  qb / 2*pi
-
+	
 	double root = p * TMath::Cos(alpha);
 	root -= qb * r_meas / TMath::Cos(alpha) / TMath::Cos(alpha);
-
+	
 	return root;
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -55,22 +55,22 @@ double alpha_derivative( double *x, double *params ){
 /// \param[in] params Various parameters required for this minimisation
 /// \returns root This number should be zero when minimised
 double butler_function( double *x, double *params ){
-
+	
 	// Equation to solve for z, LHS = 0
 	double z = x[0];
 	double z_meas = params[0];
 	double r_meas = params[1];
 	double p = params[2];	//  p
 	double qb = params[3];	//  qb / 2*pi
-
+	
 	// From Sam Bennett's first derivation, modified by A. Ceulemans
 	double theta_lab = TMath::ACos( qb * z / p );
 	double r_max = TMath::Abs( 2.0 * p * TMath::Sin( theta_lab ) / ( qb * TMath::TwoPi()) );
 	double psi = 2 * TMath::ASin( r_meas / r_max );
 	double root = z_meas - z * ( 1.0 - psi / TMath::TwoPi() );
-
+	
 	return root;
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -79,11 +79,11 @@ double butler_function( double *x, double *params ){
 /// \param[in] params Various parameters required for this minimisation
 /// \returns The derivative of the minimisation function
 double butler_derivative( double *x, double *params ){
-
+	
 	// Create the original function and solve the derivative
 	std::unique_ptr<TF1> func = std::make_unique<TF1>( "butler_function", butler_function, 0.0, TMath::PiOver2(), 4 );
 	return func->Derivative( x[0], params );
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -92,7 +92,7 @@ double butler_derivative( double *x, double *params ){
 /// \param[in] params Various parameters required for this minimisation
 /// \returns root This number should be zero when minimised
 double theta_cm_function( double *x, double *params ){
-
+	
 	// Input to the function
 	double theta_cm = x[0];
 	double z_meas = params[0];
@@ -114,13 +114,13 @@ double theta_cm_function( double *x, double *params ){
 	double E_lab = T1 + m1 + m2;
 	double gamma = E_lab / Etot_cm;
 	double beta = TMath::Sqrt( 1.0 - 1.0 / TMath::Power( gamma, 2.0 ) );
-
+	
 	// What about the energy of the ejectile after the collision?
 	double e3_cm = TMath::Power( Etot_cm, 2.0 );
 	e3_cm -= TMath::Power( m4 + Ex, 2.0 );
 	e3_cm += TMath::Power( m3, 2.0 );
 	e3_cm /= 2.0 * Etot_cm;
-
+	
 	// Now the momentum and velocity of the ejectile
 	double p3_cm = TMath::Power( e3_cm, 2.0 );
 	p3_cm -= TMath::Power( m3, 2.0 );
@@ -133,12 +133,12 @@ double theta_cm_function( double *x, double *params ){
 	theta_lab /= gamma;
 	theta_lab = TMath::ATan( theta_lab );
 	if( theta_lab < 0 ) theta_lab = TMath::Pi() + theta_lab;
-
+	
 	// Energy of ejectile in the lab
 	double e3_lab = gamma * beta * p3_cm * TMath::Cos( TMath::Pi() - theta_cm );
 	e3_lab += gamma * e3_cm;
 	double p3_lab = TMath::Sqrt( e3_lab*e3_lab - m3*m3 );
-
+	
 	// Maximum radius of particle, z position and missing orbit fraction (psi)
 	double r_max = TMath::Abs( 2.0 * p3_lab * TMath::Sin( theta_lab ) / ( qb * TMath::TwoPi()) );
 	double z = p3_lab * TMath::Cos( theta_lab ) / qb;
@@ -146,9 +146,9 @@ double theta_cm_function( double *x, double *params ){
 	
 	// This is the equation to find the root of
 	double root = z_meas - z * ( 1.0 - psi / TMath::TwoPi() );
-
+	
 	return root;
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -157,7 +157,7 @@ double theta_cm_function( double *x, double *params ){
 /// \param[in] params Various parameters required for this minimisation
 /// \returns derivative of theta_cm_function
 double theta_cm_derivative( double *x, double *params ){
-
+	
 	// Create the original function and solve the derivative
 	std::unique_ptr<TF1> func = std::make_unique<TF1>( "theta_cm_function", theta_cm_function, 0.0, TMath::Pi(), 9 );
 	return func->Derivative( x[0], params );
@@ -172,7 +172,7 @@ double theta_cm_derivative( double *x, double *params ){
 /// \param[in] myset A pointer to the ISSSettings object
 /// \param[in] source A boolean to check if this run is a source run
 ISSReaction::ISSReaction( std::string filename, std::shared_ptr<ISSSettings> myset, bool source ){
-		
+	
 	// Setup the ROOT finder algorithms
 #ifdef butler_algorithm
 	// Root finder algorithm - The Peter Butler method
@@ -188,18 +188,18 @@ ISSReaction::ISSReaction( std::string filename, std::shared_ptr<ISSSettings> mys
 	fb = new TF1( "alpha_derivative", alpha_derivative, 0.0, TMath::PiOver2(), 4 );
 #endif
 	rf = std::make_unique<ROOT::Math::RootFinder>( ROOT::Math::RootFinder::kGSL_NEWTON );
-
+	
 	// Root finder for the simulation function
 	fsim = new TF1( "theta_cm_function",   theta_cm_function,   0.0, TMath::Pi(), 9 );
 	dsim = new TF1( "theta_cm_derivative", theta_cm_derivative, 0.0, TMath::Pi(), 9 );
 	rfsim = std::make_unique<ROOT::Math::RootFinder>( ROOT::Math::RootFinder::kGSL_NEWTON );
-
+	
 	// Read in mass tables
 	ReadMassTables();
 	
 	// Check if it's a source run
 	flag_source = source;
-
+	
 	// Get the info from the user input
 	set = myset;
 	SetFile( filename );
@@ -305,7 +305,7 @@ void ISSReaction::AddBindingEnergy( short Ai, short Zi, TString ame_be_str ) {
 	// Remove # from AME data and replace with decimal point
 	if ( ame_be_str.Contains("#") )
 		ame_be_str.ReplaceAll("#",".");
-
+	
 	// An * means there is no data, fill with a 0
 	if ( ame_be_str.Contains("*") )
 		ame_be.insert( std::make_pair( isotope_key, 0 ) );
@@ -322,7 +322,7 @@ void ISSReaction::AddBindingEnergy( short Ai, short Zi, TString ame_be_str ) {
 /// Stores the binding energies per nucleon for each nucleus from the AME 
 /// 2020 file
 void ISSReaction::ReadMassTables() {
-
+	
 	// Input data file is in the source code
 	// AME_FILE is passed as a definition at compilation time in Makefile
 	std::ifstream input_file;
@@ -332,10 +332,10 @@ void ISSReaction::ReadMassTables() {
 	std::string startline = "1N-Z";
 	
 	short Ai, Zi, Ni;
-
+	
 	// Loop over the file
 	if( input_file.is_open() ){
-
+		
 		// Read first line
 		std::getline( input_file, line );
 		
@@ -350,7 +350,7 @@ void ISSReaction::ReadMassTables() {
 				exit(1);
 				
 			}
-
+			
 		}
 		
 		// Read one more nonsense line with the units on
@@ -384,7 +384,7 @@ void ISSReaction::ReadMassTables() {
 	}
 	
 	return;
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -392,7 +392,7 @@ void ISSReaction::ReadMassTables() {
 /// ReadStoppingPowers function for each of the nuclides going through the 
 /// different materials for later corrections.
 void ISSReaction::ReadReaction() {
-
+	
 	TEnv *config = new TEnv( fInputFile.data() );
 	
 	std::string isotope_key;
@@ -403,7 +403,7 @@ void ISSReaction::ReadReaction() {
 	// Detector to target distances and dead layer of Si
 	z0 = config->GetValue( "ArrayDistance", -100.0 );
 	deadlayer = config->GetValue( "ArrayDeadlayer", 0.0004 ); // units of mm of Al
-
+	
 	// Get particle properties
 	Beam.SetA( config->GetValue( "BeamA", 30 ) );
 	Beam.SetZ( config->GetValue( "BeamZ", 12 ) );
@@ -415,7 +415,7 @@ void ISSReaction::ReadReaction() {
 		
 	}
 	Beam.SetBindingEnergy( ame_be.at( Beam.GetIsotope() ) );
-
+	
 	Eb = config->GetValue( "BeamE", 8520.0 ); // in keV/u
 	Eb *= Beam.GetMass_u(); // keV
 	Beam.SetEnergyLab( Eb ); // keV
@@ -431,7 +431,7 @@ void ISSReaction::ReadReaction() {
 		
 	}
 	Target.SetBindingEnergy( ame_be.at( Target.GetIsotope() ) );
-
+	
 	Ejectile.SetA( config->GetValue( "EjectileA", 1 ) );
 	Ejectile.SetZ( config->GetValue( "EjectileZ", 1 ) );
 	if( Ejectile.GetZ() < 0 || Ejectile.GetZ() >= (int)gElName.size() ){
@@ -442,7 +442,7 @@ void ISSReaction::ReadReaction() {
 		
 	}
 	Ejectile.SetBindingEnergy( ame_be.at( Ejectile.GetIsotope() ) );
-
+	
 	Recoil.SetA( config->GetValue( "RecoilA", 31 ) );
 	Recoil.SetZ( config->GetValue( "RecoilZ", 12 ) );
 	if( Recoil.GetZ() < 0 || Recoil.GetZ() >= (int)gElName.size() ){
@@ -460,24 +460,24 @@ void ISSReaction::ReadReaction() {
 	recoilcutfile.resize( nrecoilcuts );
 	recoilcutname.resize( nrecoilcuts );
 	for( unsigned int i = 0; i < nrecoilcuts; ++i ) {
-	
+		
 		recoilcutfile.at(i) = config->GetValue( Form( "RecoilCut_%d.File", i ), "NULL" );
 		recoilcutname.at(i) = config->GetValue( Form( "RecoilCut_%d.Name", i ), "CUTG" );
 		
 		// Check if it is given by the user
 		if( recoilcutfile.at(i) != "NULL" ) {
-		
+			
 			TFile *recoil_file = new TFile( recoilcutfile.at(i).data(), "READ" );
 			if( recoil_file->IsZombie() )
 				std::cout << "Couldn't open " << recoilcutfile.at(i) << " correctly" << std::endl;
-				
-			else {
 			
+			else {
+				
 				if( !recoil_file->GetListOfKeys()->Contains( recoilcutname.at(i).data() ) )
 					std::cout << "Couldn't find " << recoilcutname.at(i) << " in " << recoilcutfile.at(i) << std::endl;
 				else
 					recoil_cut.at(i) = std::make_shared<TCutG>( *static_cast<TCutG*>( recoil_file->Get( recoilcutname.at(i).data() )->Clone() ) );
-
+				
 			}
 			
 			recoil_file->Close();
@@ -486,7 +486,7 @@ void ISSReaction::ReadReaction() {
 		
 		// Assign an empty cut file if none is given, so the code doesn't crash
 		if( !recoil_cut.at(i) ) recoil_cut.at(i) = std::make_shared<TCutG>();
-	
+		
 	}
 	
 	// Get E versus z cuts
@@ -495,24 +495,24 @@ void ISSReaction::ReadReaction() {
 	evszcutfile.resize( nevszcuts );
 	evszcutname.resize( nevszcuts );
 	for( unsigned int i = 0; i < nevszcuts; ++i ) {
-	
+		
 		evszcutfile.at(i) = config->GetValue( Form( "EvsZCut_%d.File", i ), "NULL" );
 		evszcutname.at(i) = config->GetValue( Form( "EvsZCut_%d.Name", i ), "CUTG" );
 		
 		// Check if it is given by the user
 		if( evszcutfile.at(i) != "NULL" ) {
-		
+			
 			TFile *e_vs_z_file = new TFile( evszcutfile.at(i).data(), "READ" );
 			if( e_vs_z_file->IsZombie() )
 				std::cout << "Couldn't open " << evszcutfile.at(i) << " correctly" << std::endl;
-				
-			else {
 			
+			else {
+				
 				if( !e_vs_z_file->GetListOfKeys()->Contains( evszcutname.at(i).data() ) )
 					std::cout << "Couldn't find " << evszcutname.at(i) << " in " << evszcutfile.at(i) << std::endl;
 				else
 					e_vs_z_cut.at(i) = std::make_shared<TCutG>( *static_cast<TCutG*>( e_vs_z_file->Get( evszcutname.at(i).data() )->Clone() ) );
-
+				
 			}
 			
 			e_vs_z_file->Close();
@@ -521,7 +521,7 @@ void ISSReaction::ReadReaction() {
 		
 		// Assign an empty cut file if none is given, so the code doesn't crash
 		if( !e_vs_z_cut.at(i) ) e_vs_z_cut.at(i) = std::make_shared<TCutG>();
-	
+		
 	}
 	
 	// EBIS time window
@@ -530,32 +530,32 @@ void ISSReaction::ReadReaction() {
 	EBIS_On = config->GetValue( "EBIS_On", tmp_on );	// backwards compatibility
 	EBIS_Off = config->GetValue( "EBIS_Off", tmp_off );	// backwards compatibility window 20 times bigger than on
 	EBIS_ratio = config->GetValue( "EBIS.FillRatio", GetEBISTimeRatio() );	// this is the measured ratio of EBIS On/off. Default is just the time window ratio
-
+	
 	// T1 time window
 	t1_min_time = config->GetValue( "T1.Min", 0 );		// default = 0
 	t1_max_time = config->GetValue( "T1.Max", 1.2e9 );	// default = 1.2 seconds
-
+	
 	
 	// Array-Recoil time windows
 	array_recoil_prompt[0] = config->GetValue( "ArrayRecoil_PromptTime.Min", -300 );	// lower limit for array-recoil prompt time difference
 	array_recoil_prompt[1] = config->GetValue( "ArrayRecoil_PromptTime.Max", 300 );		// upper limit for array-recoil prompt time difference
 	array_recoil_random[0] = config->GetValue( "ArrayRecoil_RandomTime.Min", 600 );		// lower limit for array-recoil random time difference
 	array_recoil_random[1] = config->GetValue( "ArrayRecoil_RandomTime.Max", 1200 );	// upper limit for array-recoil random time difference
-
+	
 	// Array-Recoil fill ratios
 	array_recoil_ratio = config->GetValue( "ArrayRecoil_FillRatio", GetArrayRecoilTimeRatio() );
-
+	
 	// Target thickness and offsets
 	target_thickness = config->GetValue( "TargetThickness", 0.200 ); // units of mg/cm^2
 	x_offset = config->GetValue( "TargetOffset.X", 0.0 );	// of course this should be 0.0 if you centre the beam! Units of mm, vertical
 	y_offset = config->GetValue( "TargetOffset.Y", 0.0 );	// of course this should be 0.0 if you centre the beam! Units of mm, horizontal
-
+	
 	// ELUM geometry
 	elum_z    		= config->GetValue( "ELUM.Distance", -1.0 ); // units of mm
 	elum_rin  		= config->GetValue( "ELUM.InnerRadius", 24.0 ); // units of mm
 	elum_rout 		= config->GetValue( "ELUM.OuterRadius", 48.0 ); // units of mm
 	elum_deadlayer	= config->GetValue( "ELUM.Deadlayer", 0.00095 ); // units of mm of Si equivalent
-
+	
 	// If it's a source run, we can ignore most of that
 	// or better still, initialise everything and overwrite what we need
 	if( flag_source ){
@@ -580,18 +580,18 @@ void ISSReaction::ReadReaction() {
 		stopping &= ReadStoppingPowers( Ejectile.GetIsotope(), Target.GetIsotope(), gStopping[1], gRange[1] );
 	}
 	stopping &= ReadStoppingPowers( Ejectile.GetIsotope(), "Al", gStopping[2], gRange[2] );
-
+	
 	// Get the electric and nuclear stopping powers for the PHC in a TGraph
 	phcurves = true;
 	phcurves &= ReadStoppingPowers( Ejectile.GetIsotope(), "Si", gStopping[3], gRange[3], true, false ); // electric only from SRIM files
 	phcurves &= ReadStoppingPowers( Ejectile.GetIsotope(), "Si", gStopping[4], gRange[4], false, true ); // nuclear only from SRIM files
 	phcurves &= ReadStoppingPowers( Ejectile.GetIsotope(), "Si", gStopping[5], gRange[5] );				 // total stopping from SRIM files
-
+	
 	// Get the PHC data in a TGraph
 	gPHC = std::make_unique<TGraph>();
 	gPHC_inv = std::make_unique<TGraph>();
 	CalculatePulseHeightCorrection( Ejectile.GetIsotope() );
-
+	
 	// Some diagnostics and info
 	if( !flag_source ) {
 		
@@ -604,7 +604,7 @@ void ISSReaction::ReadReaction() {
 		std::cout << Beam.GetEnergyLab()*0.001 << " MeV" << std::endl;
 		std::cout << "Target thickness = ";
 		std::cout << target_thickness << " mg/cm^2" << std::endl;
-
+		
 	}
 	else std::cout << std::endl << " +++  Alpha Source Run  +++" << std::endl;
 	
@@ -613,17 +613,17 @@ void ISSReaction::ReadReaction() {
 		
 		// But only if it's not a source run
 		if( !flag_source ) {
-		
+			
 			double eloss = GetEnergyLoss( Beam.GetEnergyLab(), 0.5 * target_thickness, gStopping[0] );
 			Beam.SetEnergyLab( Beam.GetEnergyLab() - eloss );
 			std::cout << "Beam energy at centre of target = ";
 			std::cout << Beam.GetEnergyLab()*0.001 << " MeV" << std::endl;
-
+			
 		}
 		
 	}
 	else std::cout << "Stopping powers not calculated" << std::endl;
-
+	
 	
 	// Do some ELUM calculations
 	double theta_cm_inner,  theta_cm_outer,  theta_cm_centre;
@@ -639,7 +639,7 @@ void ISSReaction::ReadReaction() {
 		int tmpA2 = Recoil.GetA();
 		int tmpZ2 = Recoil.GetZ();
 		double tmpBE2 = Recoil.GetBindingEnergy();
-
+		
 		// Then pretend we have elastic scattering
 		Ejectile.SetA( Target.GetA() );
 		Ejectile.SetZ( Target.GetZ() );
@@ -647,18 +647,18 @@ void ISSReaction::ReadReaction() {
 		Recoil.SetA( Beam.GetA() );
 		Recoil.SetZ( Beam.GetZ() );
 		Recoil.SetBindingEnergy( Beam.GetBindingEnergy() );
-
+		
 		//std::cout << std::endl << " +++  ";
 		//std::cout << Beam.GetIsotope() << "(" << Target.GetIsotope() << ",";
 		//std::cout << Ejectile.GetIsotope() << ")" << Recoil.GetIsotope();
 		//std::cout << "  +++" << std::endl;
 		//std::cout << "Q-value = " << GetQvalue()*0.001 << " MeV" << std::endl;
-
+		
 		// Define interaction position of the inner/outer edges and centre
 		TVector3 elum_inner_hit( elum_rin,  0.0, elum_z );
 		TVector3 elum_outer_hit( elum_rout, 0.0, elum_z );
 		TVector3 elum_centre_hit( 0.5*(elum_rout+elum_rin), 0.0, elum_z );
-
+		
 		// Simulate the elastic scattering reaction - inner
 		SimulateReaction( elum_inner_hit );
 		theta_cm_inner  = Recoil.GetThetaCM();
@@ -667,7 +667,7 @@ void ISSReaction::ReadReaction() {
 		enloss_inner = GetEnergyLoss( energy_inner,
 									 elum_deadlayer / TMath::Abs( TMath::Cos( theta_lab_inner ) ),
 									 gStopping[2] );
-
+		
 		// Simulate the elastic scattering reaction - outer
 		SimulateReaction( elum_outer_hit );
 		theta_cm_outer  = Recoil.GetThetaCM();
@@ -676,16 +676,16 @@ void ISSReaction::ReadReaction() {
 		enloss_outer = GetEnergyLoss( energy_outer,
 									 elum_deadlayer / TMath::Abs( TMath::Cos( theta_lab_outer ) ),
 									 gStopping[2] );
-
+		
 		// Simulate the elastic scattering reaction - centre
 		SimulateReaction( elum_centre_hit );
 		theta_cm_centre  = Recoil.GetThetaCM();
 		theta_lab_centre = Ejectile.GetThetaLab();
 		energy_centre = Ejectile.GetEnergyLab();
 		enloss_centre = GetEnergyLoss( energy_centre,
-									 elum_deadlayer / TMath::Abs( TMath::Cos( theta_lab_centre ) ),
-									 gStopping[2] );
-
+									  elum_deadlayer / TMath::Abs( TMath::Cos( theta_lab_centre ) ),
+									  gStopping[2] );
+		
 		// Change ejectile and recoils back again
 		Ejectile.SetA( tmpA );
 		Ejectile.SetZ( tmpZ );
@@ -693,7 +693,7 @@ void ISSReaction::ReadReaction() {
 		Recoil.SetA( tmpA2 );
 		Recoil.SetZ( tmpZ2 );
 		Recoil.SetBindingEnergy( tmpBE2 );
-
+		
 		std::cout << std::setprecision(5);
 		std::cout << "ELUM found at " << elum_z << " mm" << std::endl;
 		std::cout << " θ_cm = " << theta_cm_centre * TMath::RadToDeg();
@@ -705,12 +705,12 @@ void ISSReaction::ReadReaction() {
 		std::cout << " < E_lab < " << energy_outer << " keV" << std::endl;
 		std::cout << "\t" << energy_inner - enloss_inner << " < E_det < ";
 		std::cout << energy_outer - enloss_outer << " keV " << std::endl;
-
+		
 	}
 	
 	// Finished
 	delete config;
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -723,24 +723,26 @@ void ISSReaction::ReadReaction() {
 /// \param[in] g The TGraph of the energy loss generated in the ISSReaction::ReadReaction() function
 /// \returns Ei-E The energy loss of a particular nuclide in a particular material
 double ISSReaction::GetEnergyLoss( double Ei, double dist, std::unique_ptr<TGraph> &g ) {
-
+	
 	unsigned int Nmeshpoints = 50; // number of steps to take in integration
 	double dx = dist/(double)Nmeshpoints;
 	double E = Ei;
 	
-	  // Create a spline for the provided TGraph
-    TSpline3* spline = new TSpline3("spline", g.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
+	// Create a spline for the provided TGraph
+	// Use akima spline to make energy loss graph smoother
+	std::unique_ptr<TSpline3> spline = std::make_unique<TSpline3>("spline", g.get(), "akima");
+	for( unsigned int i = 0; i < Nmeshpoints; i++ ) {
 
-    for (unsigned int i = 0; i < Nmeshpoints; i++) {
-        if (E < 100.) break; // when we fall below 100 keV we assume maximum energy loss
-        E -= spline->Eval(E) * dx;
-    }
+		double eloss = spline->Eval(E) * dx;
+		if( eloss > E && eloss > 0 ) eloss = E; // incase we are "stopped"
 
-    // Don't forget to delete the spline object to prevent memory leaks
-    delete spline;
+		E -= eloss;
+		if( E < 100. && eloss > 0  ) break; // when we fall below 100 keV we assume maximum energy loss
 
-    return Ei - E;
+	}
 
+	return Ei - E;
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -754,29 +756,29 @@ double ISSReaction::GetEnergyLoss( double Ei, double dist, std::unique_ptr<TGrap
 /// \param[in] gtot The TGraph of the total energy loss
 /// \returns En: The nuclear specific energy loss of a particular nuclide over the range
 double ISSReaction::GetNuclearEnergyLoss( double Ei, double range, std::unique_ptr<TGraph> &gn, std::unique_ptr<TGraph> &gtot ) {
-
+	
 	unsigned int Nmeshpoints = 200; // number of steps to take in integration
 	double dx = range/(double)Nmeshpoints;
 	double E = Ei;
 	double En = 0;
 	
 	
-    // Create splines for the provided TGraphs
-    TSpline3* splineTot = new TSpline3("splineTot", gtot.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
-    TSpline3* splineN = new TSpline3("splineN", gn.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
-
-    for (unsigned int i = 0; i < Nmeshpoints; i++) {
-        if (E < 0.5) break; // when we fall below 0.5 keV we assume we're stopped
-        E -= splineTot->Eval(E) * dx;
-        En += splineN->Eval(E) * dx;
-    }
-
-    // Delete the spline objects to prevent memory leaks
-    delete splineTot;
-    delete splineN;
-
-    return En;
-
+	// Create splines for the provided TGraphs
+	TSpline3* splineTot = new TSpline3("splineTot", gtot.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
+	TSpline3* splineN = new TSpline3("splineN", gn.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
+	
+	for (unsigned int i = 0; i < Nmeshpoints; i++) {
+		if (E < 0.5) break; // when we fall below 0.5 keV we assume we're stopped
+		E -= splineTot->Eval(E) * dx;
+		En += splineN->Eval(E) * dx;
+	}
+	
+	// Delete the spline objects to prevent memory leaks
+	delete splineTot;
+	delete splineN;
+	
+	return En;
+	
 }
 
 
@@ -794,14 +796,14 @@ double ISSReaction::GetNuclearEnergyLoss( double Ei, double range, std::unique_p
 bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2,
 									 std::unique_ptr<TGraph> &g, std::unique_ptr<TGraph> &r,
 									 bool electriconly, bool nuclearonly ) {
-
+	
 	/// Open stopping power files and make TGraphs of data
 	
 	// Change target material depending on species
 	if( isotope2 == "1H" ) isotope2 = "CH2";
 	if( isotope2 == "2H" ) isotope2 = "CD2";
 	if( isotope2 == "3H" ) isotope2 = "tTi";
-
+	
 	// Make title for stopping
 	std::string title = "Stopping powers for ";
 	title += isotope1 + " in " + isotope2;
@@ -810,7 +812,7 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 	if( isotope2 == "Si" || isotope2 == "Al" ) title += " [keV/mm]";
 	else title += " [keV/(mg/cm^{2})]";
 	g->SetTitle( title.c_str() );
-
+	
 	// Make title for range
 	title = "Range of ";
 	title += isotope1 + " in " + isotope2;
@@ -822,10 +824,10 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 	// Start graphs fresh
 	g->Set(0);
 	r->Set(0);
-
+	
 	// Keep things quiet from ROOT
 	gErrorIgnoreLevel = kWarning;
-
+	
 	// Open the data file
 	// SRIM_DIR is defined at compilation and is in source code
 	std::string srimfilename = std::string( SRIM_DIR ) + "/";
@@ -833,20 +835,20 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 	
 	std::ifstream input_file;
 	input_file.open( srimfilename, std::ios::in );
-
+	
 	// If it fails to open print an error
 	if( !input_file.is_open() ) {
 		
 		std::cerr << "Cannot open " << srimfilename << std::endl;
 		return false;
-		  
+		
 	}
-
-
+	
+	
 	std::string line, units, length, tmp_str;
 	std::stringstream line_ss;
 	double En, nucl, elec, total, range, tmp_dbl;
-	 
+	
 	// Test file format
 	std::getline( input_file, line );
 	if( line.substr( 3, 5 ) == "=====" ) {
@@ -869,13 +871,13 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 		return false;
 		
 	}
-
+	
 	// Read in the data
 	while( std::getline( input_file, line ) && !input_file.eof() ) {
 		
 		// Skip over the really short lines
 		if( line.length() < 10 ) continue;
-
+		
 		// If we've reached the end, stop
 		if( line.substr( 3, 9 ) == "---------" ) break;
 		
@@ -895,14 +897,14 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 		else if( length == "mm" ) range *= 1E0;
 		else if( length == "m" ) range *= 1E3;
 		else if( length == "km" ) range *= 1E6;
-
+		
 		if( electriconly ) total = elec; // electric stopping only
 		else if( nuclearonly ) total = nucl; // nuclear stopping only
 		else total = nucl + elec ; // in some units, conversion done later
 		
 		g->SetPoint( g->GetN(), En, total );
 		r->SetPoint( g->GetN(), En, range );
-
+		
 	}
 	
 	// Get next line and check there are conversion factors
@@ -915,7 +917,7 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 		
 	}
 	std::getline( input_file, line ); // next line is just ------
-
+	
 	// Get conversion factors
 	double conv, conv_keVum, conv_MeVmgcm2;
 	std::getline( input_file, line ); // first conversion is eV / Angstrom
@@ -949,15 +951,15 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 	r->Draw("A*");
 	pdfname = srimfilename.substr( 0, srimfilename.find_last_of(".") ) + "_range.pdf";
 	c->SaveAs( pdfname.c_str() );
-
+	
 	delete c;
 	input_file.close();
 	
 	// ROOT can be noisy again
 	gErrorIgnoreLevel = kInfo;
-
+	
 	return true;
-	 
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -966,19 +968,19 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 /// \param[in] detected Should be true if this is the detected energy and false if it is the actual ion energy
 /// \return energy correction to obtain the true ion energy (if detected) or the charge collected (if !detected)
 double ISSReaction::GetPulseHeightCorrection( double Ei, bool detected ) {
-
+	
 	// If we failed to read the data, return a zero correction value
 	if( !phcurves ) return 0;
-
+	
 	if( detected ) return gPHC_inv->Eval(Ei); // get actual ion energy from PH (detected energy)
 	else return gPHC->Eval(Ei); // get PH for actual ion energy
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Calculates the pulse height correction information from the SRIM data
 void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
-	 
+	
 	/// Open stopping power files and make TGraphs of data
 	
 	// Make titles
@@ -990,41 +992,41 @@ void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
 	title_inv += isotope;
 	title_inv += ";Deposited energy [keV/#mum];";
 	title_inv += isotope + " energy after dead layer [keV]";
-
+	
 	// Initialise an empty TGraph
 	gPHC->SetTitle( title.c_str() );
 	gPHC_inv->SetTitle( title_inv.c_str() );
-
+	
 	// Keep things quiet from ROOT
 	gErrorIgnoreLevel = kWarning;
-
+	
 	// Read in the data to a temporary graph
 	TGraph *gRes = new TGraph();
-
+	
 	// Calculate the stopping
 	double E, Emax = 100e3;
 	double range, dEdx_n, dEdx_e;
-
+	
 	// number of steps to take in integration
 	unsigned int Nmeshpoints = 2e4;
 	double dE = Emax/(double)Nmeshpoints;
 	double Edet = 0.0;
-
+	
 	// Create splines for the TGraphs used in the calculation
-    TSpline3* splineRange = new TSpline3("splineRange", gRange[3].get(), "akima"); // // Use akima spline to make phc smoother - BRJ
-    TSpline3* splineStoppingPower = new TSpline3("splineStoppingPower", gStopping[3].get(), "akima"); //Use akima spline to make phc smoother - BRJ
-
-
+	TSpline3* splineRange = new TSpline3("splineRange", gRange[3].get(), "akima"); // // Use akima spline to make phc smoother - BRJ
+	TSpline3* splineStoppingPower = new TSpline3("splineStoppingPower", gStopping[3].get(), "akima"); //Use akima spline to make phc smoother - BRJ
+	
+	
 	// Do the numerical integration
 	for( unsigned int i = 0; i < Nmeshpoints; i++ ){
-
+		
 		E = (double)i + 0.5;
 		E *= dE;
 		
 		// Evaluate stopping powers and range
-	    range = splineRange->Eval(E);
-        dEdx_e = splineStoppingPower->Eval(E);
-
+		range = splineRange->Eval(E);
+		dEdx_e = splineStoppingPower->Eval(E);
+		
 		// Calculate the nuclear stopping
 		// NB: this is inefficient, but still only takes a couple of seconds
 		// ideally the integrated nuclear energy loss versus energy would be
@@ -1048,7 +1050,7 @@ void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
 		gPHC->SetPoint( gPHC->GetN(), E + dEdx_n, Edet );
 		gPHC_inv->SetPoint( gPHC_inv->GetN(), Edet, E + dEdx_n );
 		gRes->SetPoint( gRes->GetN(), E + dEdx_n, Edet - E - dEdx_n );
-
+		
 	}
 	
 	// Draw the plot and save it somewhere
@@ -1060,22 +1062,22 @@ void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
 	gRes->GetXaxis()->SetTitle("E_{0} (keV)");
 	std::string pdfname = std::string( SRIM_DIR ) + "/" + isotope + "_phc.pdf";
 	c->SaveAs( pdfname.c_str() );
-
-	// BRJ - these lines make root files for PH residual and eloss for the isotope that is read in 
-
+	
+	// BRJ - these lines make root files for PH residual and eloss for the isotope that is read in
+	
 	std::string tfilenameroot = std::string( SRIM_DIR ) + "/" + isotope + "_phc.root";
 	TFile *tfile = new TFile(tfilenameroot.c_str(),"recreate");
 	gRes->Write("gRes");
 	tfile->Close();
-
+	
 	delete c;
 	delete gRes;
 	delete splineRange;
-    delete splineStoppingPower;
+	delete splineStoppingPower;
 	
 	// ROOT can be noisy again
 	gErrorIgnoreLevel = kInfo;
-	 
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1115,7 +1117,7 @@ double ISSReaction::SimulateEmission( double en, double theta_lab, double phi_la
 	// cyclotron radius
 	double r_cyc = Ejectile.GetMomentumLab() * TMath::Sin( theta_lab );
 	r_cyc /= (double)Ejectile.GetZ() * GetField_corr();
-
+	
 	// measured z distance needs radius of detection
 	// TODO: this will depend on the phi emission angle
 	double r_det = 28.75; // for now just assume standard detector radius
@@ -1149,28 +1151,28 @@ double ISSReaction::SimulateEmission( double en, double theta_lab, double phi_la
 /// \param[in] detector The detector to simulate: 0 = array, 1 = ELUM, 2 = recoil Si
 /// \returns en-eloss
 double ISSReaction::SimulateDecay( TVector3 vec, double en, int detector ){
-
+	
 	// Apply the X and Y offsets directly to the TVector3 input
 	// We move the array opposite to the target, which replicates the same
 	// geometrical shift that is observed with respect to the beam
 	vec.SetX( vec.X() - x_offset );
 	vec.SetY( vec.Y() - y_offset );
-
+	
 	// Set the input parameters, might use them in another function
 	Ejectile.SetEnergyLab(en);			// ejectile energy in keV
 	z_meas = vec.Z();					// measured z in mm
 	if( z0 < 0 ) z_meas = z0 - z_meas;	// upstream
 	else z_meas += z0;					// downstream
-
-    //------------------------//
-    // Kinematics calculation //
-    //------------------------//
+	
+	//------------------------//
+	// Kinematics calculation //
+	//------------------------//
 	params[0] = z_meas;										// z in mm
 	params[1] = vec.Perp();									// r_meas in mm
 	params[2] = Ejectile.GetMomentumLab();					// p3
 	params[3] = (double)Ejectile.GetZ() * GetField_corr(); 	// qb
 	params[3] /= TMath::TwoPi(); 							// qb/2pi
-		
+	
 	// Set parameters
 	fa->SetParameters( params );
 	fb->SetParameters( params );
@@ -1180,14 +1182,14 @@ double ISSReaction::SimulateDecay( TVector3 vec, double en, int detector ){
 	ROOT::Math::GradFunctor1D wf( *fa, *fb );
 	rf->SetFunction( wf, z_meas );
 	rf->Solve( 500, 1e-5, 1e-6 );
-
+	
 	// Check result
 	if( rf->Status() ){
 		z = TMath::QuietNaN();
 	}
 	else z = rf->Root();
 	gErrorIgnoreLevel = kInfo; // print info and above again
-
+	
 	// Calculate the lab angle from z position (Butler method)
 	alpha  = (double)Ejectile.GetZ() * GetField_corr(); 	// qb
 	alpha /= TMath::TwoPi(); 							// qb/2pi
@@ -1209,7 +1211,7 @@ double ISSReaction::SimulateDecay( TVector3 vec, double en, int detector ){
 	//std::cout << dist*1e3 << " µm: " << en << " - " << eloss << std::endl;
 	
 	return en - eloss;
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1219,21 +1221,21 @@ double ISSReaction::SimulateDecay( TVector3 vec, double en, int detector ){
 /// One must set things like beam energy, excitation energy, etc, in advance
 /// \param[in] vec detection position vector
 void ISSReaction::SimulateReaction( TVector3 vec ){
-
+	
 	// Apply the X and Y offsets directly to the TVector3 input
 	// We move the array opposite to the target, which replicates the same
 	// geometrical shift that is observed with respect to the beam
 	vec.SetX( vec.X() - x_offset );
 	vec.SetY( vec.Y() - y_offset );
-
+	
 	// Set the input parameters, might use them in another function
 	//Ejectile.SetEnergyLab(en);		// ejectile energy in keV
 	z_meas = vec.Z();					// measured z in mm
 	r_meas = vec.Perp();				// measured radius
-
+	
 	//------------------------//
-    // Kinematics calculation //
-    //------------------------//
+	// Kinematics calculation //
+	//------------------------//
 	params[0] = z_meas;										// z in mm
 	params[1] = r_meas;										// r_meas in mm
 	params[2] = Recoil.GetEx();								// Ex
@@ -1244,14 +1246,14 @@ void ISSReaction::SimulateReaction( TVector3 vec ){
 	params[6] = Target.GetMass();
 	params[7] = Ejectile.GetMass();
 	params[8] = Recoil.GetMass();
-
+	
 	//for( int i = 0; i < 9; ++i )
 	//	std::cout << "params[" << i << "] = " << params[i] << ";" << std::endl;
-
+	
 	// Set parameters
 	fsim->SetParameters( params );
 	dsim->SetParameters( params );
-
+	
 	// Build the theta_cm function, then solve
 	gErrorIgnoreLevel = kBreak; // suppress warnings and errors, but not breaks
 	ROOT::Math::GradFunctor1D wf( *fsim, *dsim );
@@ -1261,11 +1263,11 @@ void ISSReaction::SimulateReaction( TVector3 vec ){
 	}
 	else theta_cm = TMath::QuietNaN();
 	gErrorIgnoreLevel = kInfo; // print info and above again
-
+	
 	// Set the theta_cm of the ejectile
 	Ejectile.SetThetaCM( TMath::Pi() - theta_cm );
 	Recoil.SetThetaCM( theta_cm );
-
+	
 	// What about the energy of the ejectile after the collision?
 	e3_cm = TMath::Power( GetEnergyTotCM(), 2.0 );
 	e3_cm -= TMath::Power( Recoil.GetMass() + Recoil.GetEx(), 2.0 );
@@ -1279,14 +1281,14 @@ void ISSReaction::SimulateReaction( TVector3 vec ){
 	theta_lab /= GetGamma();
 	theta_lab = TMath::ATan( theta_lab );
 	Ejectile.SetThetaLab( theta_lab );
-
+	
 	// Energy of ejectile in the lab
 	double e3_lab = TMath::Cos( Ejectile.GetThetaCM() );
 	e3_lab *= GetBeta() * Ejectile.GetMomentumCM();
 	e3_lab += Ejectile.GetEnergyTotCM();
 	e3_lab *= GetGamma();
 	Ejectile.SetEnergyLab( e3_lab - Ejectile.GetMass() );
-
+	
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1313,10 +1315,10 @@ void ISSReaction::MakeReaction( TVector3 vec, double en ){
 	// Pulse height conversion to proton energy using RDP
 	en = GetPulseHeightCorrection( en, true );
 	Ejectile.SetEnergyLab(en);
-
+	
 	//------------------------//
-    // Kinematics calculation //
-    //------------------------//
+	// Kinematics calculation //
+	//------------------------//
 	params[0] = z_meas;										// z in mm
 	params[1] = r_meas;										// r_meas in mm
 	params[2] = Ejectile.GetMomentumLab();					// p
@@ -1330,13 +1332,13 @@ void ISSReaction::MakeReaction( TVector3 vec, double en ){
 	// Keep going for 50 iterations or until we are better than 0.01% change
 	unsigned int iter = 0;
 	gErrorIgnoreLevel = kBreak; // suppress warnings and errors, but not breaks
-
+	
 #ifdef butler_algorithm
 	z = z_meas;
 	double z_prev = 0.0;
-
+	
 	while( TMath::Abs( ( z - z_prev ) / z ) > 0.00001 && iter < 50 ) {
-
+		
 		// Calculate the lab angle from z position (Butler method)
 		alpha  = (double)Ejectile.GetZ() * GetField_corr(); 	// qb
 		alpha /= TMath::TwoPi(); 							// qb/2pi
@@ -1345,123 +1347,123 @@ void ISSReaction::MakeReaction( TVector3 vec, double en ){
 		alpha  = TMath::ASin( alpha );
 		
 #else
-	alpha = TMath::PiOver4();
-	double alpha_prev = 9999.;
-	
-	while( TMath::Abs( ( alpha - alpha_prev ) / alpha ) > 0.0001 && iter < 50 ) {
+		alpha = TMath::PiOver4();
+		double alpha_prev = 9999.;
+		
+		while( TMath::Abs( ( alpha - alpha_prev ) / alpha ) > 0.0001 && iter < 50 ) {
 #endif
-
-		// Distance is negative because energy needs to be recovered
-		// First we recover the energy lost in the Si dead layer
-		double dist = -1.0 * deadlayer / TMath::Abs( TMath::Cos( alpha ) );
-		double eloss = GetEnergyLoss( en, dist, gStopping[2] );
-		Ejectile.SetEnergyLab( en - eloss );
-		
-		// Then we recover the energy lost in the target
-		dist = -0.5 * target_thickness / TMath::Abs( TMath::Sin( alpha ) );
-		eloss = GetEnergyLoss( Ejectile.GetEnergyLab(), dist, gStopping[1] );
-		Ejectile.SetEnergyLab( Ejectile.GetEnergyLab() - eloss );
-
-		// Set parameters
-		params[2] = Ejectile.GetMomentumLab(); // p
-		fa->SetParameters( params );
-		fb->SetParameters( params );
-		ROOT::Math::GradFunctor1D wf( *fa, *fb );
-
-#ifdef butler_algorithm
-		// Use Butler's method and solve the root
-		z_prev = z;
-		rf->SetFunction( wf, z_meas );
-		rf->Solve( 500, 1e-5, 1e-6 );
-		
-		// Check result
-		if( rf->Status() ){
-			z = TMath::QuietNaN();
-			break;
-		}
-		else z = rf->Root();
-#else
-		// Build the alpha function and derivative, then solve
-		alpha_prev = alpha;
-		rf->SetFunction( wf, 0.2 * TMath::Pi() ); // with derivatives
-		rf->Solve( 500, 1e-5, 1e-6 );
-		
-		// Check result
-		if( rf->Status() ){
-			alpha = TMath::QuietNaN();
-			break;
-		}
-		else alpha = rf->Root();
-#endif
-		
-		iter++;
 			
-	}
-	
-	gErrorIgnoreLevel = kInfo; // print info and above again
-
+			// Distance is negative because energy needs to be recovered
+			// First we recover the energy lost in the Si dead layer
+			double dist = -1.0 * deadlayer / TMath::Abs( TMath::Cos( alpha ) );
+			double eloss = GetEnergyLoss( en, dist, gStopping[2] );
+			Ejectile.SetEnergyLab( en - eloss );
+			
+			// Then we recover the energy lost in the target
+			dist = -0.5 * target_thickness / TMath::Abs( TMath::Sin( alpha ) );
+			eloss = GetEnergyLoss( Ejectile.GetEnergyLab(), dist, gStopping[1] );
+			Ejectile.SetEnergyLab( Ejectile.GetEnergyLab() - eloss );
+			
+			// Set parameters
+			params[2] = Ejectile.GetMomentumLab(); // p
+			fa->SetParameters( params );
+			fb->SetParameters( params );
+			ROOT::Math::GradFunctor1D wf( *fa, *fb );
+			
 #ifdef butler_algorithm
-	// Calculate the lab angle from z position (Butler method)
-	alpha  = (double)Ejectile.GetZ() * GetField_corr(); 	// qb
-	alpha /= TMath::TwoPi(); 							// qb/2pi
-	alpha *= z;											// * z
-	alpha /= Ejectile.GetMomentumLab();					// over p
-	alpha  = TMath::ASin( alpha );
-	double theta_lab = alpha;
-	if( z_meas < 0 ) theta_lab += TMath::PiOver2();
-	Ejectile.SetThetaLab( theta_lab );
+			// Use Butler's method and solve the root
+			z_prev = z;
+			rf->SetFunction( wf, z_meas );
+			rf->Solve( 500, 1e-5, 1e-6 );
+			
+			// Check result
+			if( rf->Status() ){
+				z = TMath::QuietNaN();
+				break;
+			}
+			else z = rf->Root();
 #else
-	// Get the real z value at beam axis and lab angle (alpha method)
-	if( z_meas < 0 ) z = z_meas - r_meas * TMath::Tan( alpha );
-	else z = z_meas + r_meas * TMath::Tan( alpha );
-	Ejectile.SetThetaLab( TMath::PiOver2() + alpha );
+			// Build the alpha function and derivative, then solve
+			alpha_prev = alpha;
+			rf->SetFunction( wf, 0.2 * TMath::Pi() ); // with derivatives
+			rf->Solve( 500, 1e-5, 1e-6 );
+			
+			// Check result
+			if( rf->Status() ){
+				alpha = TMath::QuietNaN();
+				break;
+			}
+			else alpha = rf->Root();
 #endif
-
-	// Total energy of ejectile in centre of mass
-	e3_cm = Ejectile.GetEnergyTotLab();
-	e3_cm -= GetBeta() * Ejectile.GetMomentumLab() * TMath::Sin( alpha );
-	e3_cm *= GetGamma();
-	Ejectile.SetEnergyTotCM( e3_cm );
-	Recoil.SetEnergyTotCM( GetEnergyTotCM() - e3_cm );
-
-	// Theta_CM
-	theta_cm  = Ejectile.GetEnergyTotCM();
-	theta_cm -= Ejectile.GetEnergyTotLab() / GetGamma();
-	theta_cm /= GetBeta() * Ejectile.GetMomentumCM();
-	theta_cm  = TMath::ACos( theta_cm );
-	Recoil.SetThetaCM( theta_cm );
-	Ejectile.SetThetaCM( TMath::Pi() - theta_cm );
-	
-	// Ex
-	Ex  = TMath::Power( GetEnergyTotCM(), 2.0 );
-	Ex -= 2.0 * GetEnergyTotCM() * Ejectile.GetEnergyTotCM();
-	Ex += TMath::Power( Ejectile.GetMass(), 2.0 );
-	Ex  = TMath::Sqrt( Ex ) - Recoil.GetMass();
-	Recoil.SetEx( Ex );
-	Ejectile.SetEx( 0.0 );
-	
-	
-	
-	// Debug output
-	if( z > 0 || z < 0 ){
-	
-		//std::cout << "z_meas = " << z_meas << std::endl;
-		//std::cout << "z_corr = " << z << std::endl;
-		//std::cout << "Ep = " << en << std::endl;
-		//std::cout << "alpha = " << alpha*TMath::RadToDeg() << std::endl;
-		//std::cout << "e3_cm = " << e3_cm << std::endl;
-		//std::cout << "e4_cm = " << Recoil.GetEnergyTotCM() << std::endl;
-		//std::cout << "etot_cm = " << GetEnergyTotCM() << std::endl;
-		//std::cout << "etot_lab = " << GetEnergyTotLab() << std::endl;
-		//std::cout << "gamma = " << GetGamma() << std::endl;
-		//std::cout << "beta = " << GetBeta() << std::endl;
-		//std::cout << "theta_cm = " << Recoil.GetThetaCM()*TMath::RadToDeg() << std::endl;
-		//std::cout << "Ex = " << Recoil.GetEx() << std::endl;
-		//std::cout << std::endl;
-	
+			
+			iter++;
+			
+		}
+		
+		gErrorIgnoreLevel = kInfo; // print info and above again
+		
+#ifdef butler_algorithm
+		// Calculate the lab angle from z position (Butler method)
+		alpha  = (double)Ejectile.GetZ() * GetField_corr(); 	// qb
+		alpha /= TMath::TwoPi(); 							// qb/2pi
+		alpha *= z;											// * z
+		alpha /= Ejectile.GetMomentumLab();					// over p
+		alpha  = TMath::ASin( alpha );
+		double theta_lab = alpha;
+		if( z_meas < 0 ) theta_lab += TMath::PiOver2();
+		Ejectile.SetThetaLab( theta_lab );
+#else
+		// Get the real z value at beam axis and lab angle (alpha method)
+		if( z_meas < 0 ) z = z_meas - r_meas * TMath::Tan( alpha );
+		else z = z_meas + r_meas * TMath::Tan( alpha );
+		Ejectile.SetThetaLab( TMath::PiOver2() + alpha );
+#endif
+		
+		// Total energy of ejectile in centre of mass
+		e3_cm = Ejectile.GetEnergyTotLab();
+		e3_cm -= GetBeta() * Ejectile.GetMomentumLab() * TMath::Sin( alpha );
+		e3_cm *= GetGamma();
+		Ejectile.SetEnergyTotCM( e3_cm );
+		Recoil.SetEnergyTotCM( GetEnergyTotCM() - e3_cm );
+		
+		// Theta_CM
+		theta_cm  = Ejectile.GetEnergyTotCM();
+		theta_cm -= Ejectile.GetEnergyTotLab() / GetGamma();
+		theta_cm /= GetBeta() * Ejectile.GetMomentumCM();
+		theta_cm  = TMath::ACos( theta_cm );
+		Recoil.SetThetaCM( theta_cm );
+		Ejectile.SetThetaCM( TMath::Pi() - theta_cm );
+		
+		// Ex
+		Ex  = TMath::Power( GetEnergyTotCM(), 2.0 );
+		Ex -= 2.0 * GetEnergyTotCM() * Ejectile.GetEnergyTotCM();
+		Ex += TMath::Power( Ejectile.GetMass(), 2.0 );
+		Ex  = TMath::Sqrt( Ex ) - Recoil.GetMass();
+		Recoil.SetEx( Ex );
+		Ejectile.SetEx( 0.0 );
+		
+		
+		
+		// Debug output
+		if( z > 0 || z < 0 ){
+			
+			//std::cout << "z_meas = " << z_meas << std::endl;
+			//std::cout << "z_corr = " << z << std::endl;
+			//std::cout << "Ep = " << en << std::endl;
+			//std::cout << "alpha = " << alpha*TMath::RadToDeg() << std::endl;
+			//std::cout << "e3_cm = " << e3_cm << std::endl;
+			//std::cout << "e4_cm = " << Recoil.GetEnergyTotCM() << std::endl;
+			//std::cout << "etot_cm = " << GetEnergyTotCM() << std::endl;
+			//std::cout << "etot_lab = " << GetEnergyTotLab() << std::endl;
+			//std::cout << "gamma = " << GetGamma() << std::endl;
+			//std::cout << "beta = " << GetBeta() << std::endl;
+			//std::cout << "theta_cm = " << Recoil.GetThetaCM()*TMath::RadToDeg() << std::endl;
+			//std::cout << "Ex = " << Recoil.GetEx() << std::endl;
+			//std::cout << std::endl;
+			
+		}
+		
+		return;
+		
 	}
-
-  	return;	
-
-}
-
+	

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -761,21 +761,16 @@ double ISSReaction::GetNuclearEnergyLoss( double Ei, double range, std::unique_p
 	double dx = range/(double)Nmeshpoints;
 	double E = Ei;
 	double En = 0;
-	
-	
+
 	// Create splines for the provided TGraphs
-	TSpline3* splineTot = new TSpline3("splineTot", gtot.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
-	TSpline3* splineN = new TSpline3("splineN", gn.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
+	std::unique_ptr<TSpline3> splineTot = std::make_unique<TSpline3>("splineTot", gtot.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
+	std::unique_ptr<TSpline3> splineN   = std::make_unique<TSpline3>("splineN", gn.get(), "akima"); // Use akima spline to make energy loss graph smoother - BRJ
 	
-	for (unsigned int i = 0; i < Nmeshpoints; i++) {
-		if (E < 0.5) break; // when we fall below 0.5 keV we assume we're stopped
+	for( unsigned int i = 0; i < Nmeshpoints; i++ ) {
+		if( E < 0.5 ) break; // when we fall below 0.5 keV we assume we're stopped
 		E -= splineTot->Eval(E) * dx;
 		En += splineN->Eval(E) * dx;
 	}
-	
-	// Delete the spline objects to prevent memory leaks
-	delete splineTot;
-	delete splineN;
 	
 	return En;
 	
@@ -939,7 +934,7 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 	}
 	
 	// Draw the plot and save it somewhere
-	TCanvas *c = new TCanvas();
+	std::unique_ptr<TCanvas> c = std::make_unique<TCanvas>();
 	c->SetLogx();
 	g->Draw("A*");
 	std::string pdfname = srimfilename.substr( 0, srimfilename.find_last_of(".") );
@@ -952,7 +947,6 @@ bool ISSReaction::ReadStoppingPowers( std::string isotope1, std::string isotope2
 	pdfname = srimfilename.substr( 0, srimfilename.find_last_of(".") ) + "_range.pdf";
 	c->SaveAs( pdfname.c_str() );
 	
-	delete c;
 	input_file.close();
 	
 	// ROOT can be noisy again
@@ -1001,7 +995,7 @@ void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
 	gErrorIgnoreLevel = kWarning;
 	
 	// Read in the data to a temporary graph
-	TGraph *gRes = new TGraph();
+	std::unique_ptr<TGraph> gRes = std::make_unique<TGraph>();
 	
 	// Calculate the stopping
 	double E, Emax = 100e3;
@@ -1013,8 +1007,8 @@ void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
 	double Edet = 0.0;
 	
 	// Create splines for the TGraphs used in the calculation
-	TSpline3* splineRange = new TSpline3("splineRange", gRange[3].get(), "akima"); // // Use akima spline to make phc smoother - BRJ
-	TSpline3* splineStoppingPower = new TSpline3("splineStoppingPower", gStopping[3].get(), "akima"); //Use akima spline to make phc smoother - BRJ
+	std::unique_ptr<TSpline3> splineRange         = std::make_unique<TSpline3>("splineRange", gRange[3].get(), "akima"); // // Use akima spline to make phc smoother - BRJ
+	std::unique_ptr<TSpline3> splineStoppingPower = std::make_unique<TSpline3>("splineStoppingPower", gStopping[3].get(), "akima"); //Use akima spline to make phc smoother - BRJ
 	
 	
 	// Do the numerical integration
@@ -1054,7 +1048,7 @@ void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
 	}
 	
 	// Draw the plot and save it somewhere
-	TCanvas *c = new TCanvas();
+	std::unique_ptr<TCanvas> c = std::make_unique<TCanvas>();
 	//c->SetLogx();
 	//c->SetLogy();
 	gRes->Draw("AP");
@@ -1069,11 +1063,6 @@ void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
 	TFile *tfile = new TFile(tfilenameroot.c_str(),"recreate");
 	gRes->Write("gRes");
 	tfile->Close();
-	
-	delete c;
-	delete gRes;
-	delete splineRange;
-	delete splineStoppingPower;
 	
 	// ROOT can be noisy again
 	gErrorIgnoreLevel = kInfo;


### PR DESCRIPTION
This is aiming to fix bug #26 reported by Andreas Ceulemans, specifically in commit 04febd5.

Some other things mixed up in here too, including lots of white space changes and a better checking of stopped ions in the targer or dead layers. Also added use of smart pointers in a few more places of the Reaction file to prevent memory leaks (important for later developments if we make copies of the Reaction class).