### PR TITLE
Fix bug T1.Min

### DIFF
--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -532,7 +532,7 @@ void ISSReaction::ReadReaction() {
 	EBIS_ratio = config->GetValue( "EBIS.FillRatio", GetEBISTimeRatio() );	// this is the measured ratio of EBIS On/off. Default is just the time window ratio
 	
 	// T1 time window
-	t1_min_time = config->GetValue( "T1.Min", 0 );		// default = 0
+	t1_min_time = config->GetValue( "T1.Min", 0.0 );    // default = 0
 	t1_max_time = config->GetValue( "T1.Max", 1.2e9 );	// default = 1.2 seconds
 	
 	


### PR DESCRIPTION
By providing a double as default TEnv will read a double as value from the settings file.

Before a value of 1e9 in the input file would be read as integer and thus be truncated to 1 instead of 1.000.000.000 .