### PR TITLE
Time walk correction TGraph Method 

### DIFF
--- a/calibration.dat
+++ b/calibration.dat
@@ -4,7 +4,7 @@
 # liam.gaffney@liverpool.ac.uk
 #
 # pass this file to iss_sort with the -c flag
-# 
+#
 # Format - Array calibration
 # asic_<mod>_<asic>_<ch>.Offset:	// energy calibration offset (default = -30000.0)
 # asic_<mod>_<asic>_<ch>.Gain:		// energy calirbation gain (default = 15.0)
@@ -12,8 +12,10 @@
 # asic_<mod>_<asic>_<ch>.Threshold:	// software threshold in adc units (default = 0)
 # asic_<mod>_<asic>.Time:			// time offset in ns (default = 0.0)
 # asic_<mod>_<asic>.Enabled:		// enabled (true or 1) or disable (false or 0) ASIC by ASIC (default = 1)
-# asic_<mod>_<asic>.WalkType:		// time walk function: 0 = Annie's, 1 = Sam's
+# asic_<mod>_<asic>.WalkType:		// time walk type: 0 = Annie's function, 1 = Sam's function, 2 = TGraph method
 # asic_<mod>_<asic>.Walk<N>.Hit<X>:	// time walk parameters, N (=0-4), for hit bit X (=0/1) data
+# asic_<mod>_<asic>.WalkFile.Hit<X>:	// ROOT file containing the TGraph for the time walk, for hit bit X (=0/1) data. Default: NULL
+# asic_<mod>_<asic>.WalkName.Hit<X>:	// name of the TGraph object inside the ROOT file, for hit bit X (=0/1) data. Default: Graph
 #
 # Format - CAEN calibration
 # caen_<mod>_<ch>.Offset:		// energy calibration offset (default = 0.0)

--- a/include/Calibration.hh
+++ b/include/Calibration.hh
@@ -13,6 +13,8 @@
 #include "TRandom.h"
 #include "TMath.h"
 #include "TF1.h"
+#include "TGraph.h"
+#include "TFile.h"
 #include "Math/RootFinder.h"
 #include "Math/Functor.h"
 
@@ -23,6 +25,9 @@
 
 // Number of time walk parameters
 const unsigned char nwalkpars = 4;
+
+// Hit-bit number for time walk graphs
+const unsigned char HitN = 2;
 
 /*!
 * \brief A class to read in the calibration file in ROOT's TConfig format.
@@ -206,6 +211,12 @@ private:
 	TF1 *fa;///< TF1 for the time walk function: walk_function( double *x, double *params )
 	TF1 *fb;///< TF1 for the time walk function derivative: walk_derivative( double *x, double *params )
 	double walk_params[nwalkpars+1];///< Parameters used to store time-walk parameters
+
+	// Time-walk Graphs
+	std::vector< std::vector< std::vector< std::string > > > twgraphfile;///< The location of the time walk graph files
+	std::vector< std::vector< std::vector< std::string > > > twgraphname;///< The names of the time walk graphs
+	std::vector< std::vector< std::vector< std::shared_ptr<TGraph> > > > tw_graph;///< Vector containing time walk graphs
+
 
 
 	//ClassDef(ISSCalibration, 1)

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -1379,15 +1379,13 @@ void ISSEventBuilder::ArrayFinder() {
 			// p-p time
 			for( unsigned int k = 0; k < pindex.size(); ++k )
 				for( unsigned int l = k+1; l < pindex.size(); ++l )
-					if( ptd_list.at( pindex.at(k) ) != ptd_list.at( pindex.at(l) ) ||
-					   TMath::Abs( pid_list.at( pindex.at(k) ) - pid_list.at( pindex.at(l) ) ) > 1 )
+					if(TMath::Abs( pid_list.at( pindex.at(k) ) - pid_list.at( pindex.at(l) ))==1 )
 						pp_td[i][j]->Fill( pwalk_list.at( pindex.at(k) ) - pwalk_list.at( pindex.at(l) ) );
 			
 			// n-n time
 			for( unsigned int k = 0; k < nindex.size(); ++k )
 				for( unsigned int l = k+1; l < nindex.size(); ++l )
-					if( ntd_list.at( nindex.at(k) ) != ntd_list.at( nindex.at(l) ) ||
-					   TMath::Abs( nid_list.at( nindex.at(k) ) - nid_list.at( nindex.at(l) ) ) > 1 )
+					if(TMath::Abs( nid_list.at( nindex.at(k) ) - nid_list.at( nindex.at(l) ))==1 )
 						nn_td[i][j]->Fill( nwalk_list.at( nindex.at(k) ) - nwalk_list.at( nindex.at(l) ) );
 			
 			// p-n time


### PR DESCRIPTION
Added another type of time walk correction "WalkType = 2" where you draw a TGraph over the time walk curve and evaluate the line to get the time walk for a particular energy. As you are evaluating an x value (energy) to get a y value (time) you must draw the 'J-curve' with the time walk as tdiff as a function of energy (i.e. plot the axes the other way round as it is currently). 
Save the TGraph in a root file and add the files into the calibration file, exactly the same as how EvZ and recoil cuts are read in, and the specific notation should be written as a comment in the calibration file itself.

As this simple line, time difference as a function of energy deltaT(E),  is just begin evaluated for a particular energy, no solving of functions or parameters are needed!

One thing to note is that the evaluation "->Eval(energy)" must be the simple linear interpolation as using the spline option that root has fails if you have two y-values for a particular x-value (i.e. if you have a vertical line or a 'c' shape). But a simple linear interpolation is ample, especially if many lines are drawn. The Eval() function also does a linear extrapolation, so if your line finishes pointing toward the y-axis, the function will always 'cross the y-axis', i.e. no energy threshold is introduced. Similarly with high energies.