### PR TITLE
Add laser mode flag for the users

### DIFF
--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -216,6 +216,8 @@ public:
 	inline double GetT1MinTime(){ return t1_min_time; };///< Getter for the T1 time cut minimum
 	inline double GetT1MaxTime(){ return t1_max_time; };///< Getter for the T1 time cut maximum
 
+	inline unsigned char GetLaserMode(){ return laser_mode; }; ///< Getter for LaserMode value
+	
 	inline double GetZmeasured(){ return z_meas; };///< Getter for the measured z (where the particle lands on the array)
 	inline double GetZprojected(){ return z; };///< Getter for the projected z (where the particle would intersect with the beam axis)
 	
@@ -391,6 +393,12 @@ private:
 	// T1 time window
 	double t1_max_time;	///< T1 pulse max time
 	double t1_min_time;	///< T1 pulse min time
+	
+	// Laser mode
+	unsigned char laser_mode;	///< user can select which laser data to sort, with values:
+								///< 0 = laser off NOT on
+								///< 1 = laser on NOT off
+								///< 2 = laser on OR off (default)
 
 	// Coincidence windows
 	double array_recoil_prompt[2]; ///< Prompt time windows between recoil and array event

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1290,6 +1290,10 @@ unsigned long ISSHistogrammer::FillHists() {
 		// Current event data
 		input_tree->GetEntry(i);
 		
+		// Check laser mode
+		if( react->GetLaserMode() == 0 && read_evts->GetLaserStatus() ) continue;
+		if( react->GetLaserMode() == 1 && !read_evts->GetLaserStatus() ) continue;
+
 		// tdiff variable
 		double tdiff;
 		

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -535,6 +535,8 @@ void ISSReaction::ReadReaction() {
 	t1_min_time = config->GetValue( "T1.Min", 0.0 );    // default = 0
 	t1_max_time = config->GetValue( "T1.Max", 1.2e9 );	// default = 1.2 seconds
 	
+	// Laser mode: 0 = off, 1 = on, 2 = on/off (default)
+	laser_mode = config->GetValue( "LaserMode", 0 );
 	
 	// Array-Recoil time windows
 	array_recoil_prompt[0] = config->GetValue( "ArrayRecoil_PromptTime.Min", -300 );	// lower limit for array-recoil prompt time difference


### PR DESCRIPTION
Users can now sort the mixed laser data as long as the Laser Status is in the DAQ and correctly mapped with the settings file. One can choose to sort only laser off data from within a file (LaserMode = 0), only laser on data (LaserMode = 1) or either laser on or laser off data (LaserMode = 2).