### PR TITLE
n_array_side was not initialised since its setting was not retrieved

### DIFF
--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -22,6 +22,7 @@ void ISSSettings::ReadSettings() {
 	n_array_row = config->GetValue( "NumberOfArrayRows", 4 );
 	n_array_pstrip = config->GetValue( "NumberOfArrayPstrips", 128 );
 	n_array_nstrip = config->GetValue( "NumberOfArrayNstrips", 11 );
+	n_array_side = config->GetValue( "NumberOfArraySides", 6 );
 	
 	// CAEN initialisation
 	n_caen_mod = config->GetValue( "NumberOfCAENModules", 2 );

--- a/tests/dump_settings.good
+++ b/tests/dump_settings.good
@@ -4,7 +4,7 @@ n_array_ch:               128
 n_array_row:              4
 n_array_pstrip:           128
 n_array_nstrip:           11
-n_array_side:             0
+n_array_side:             6
 n_caen_mod:               2
 n_caen_ch:                16
 caen_model[0]:            1725


### PR DESCRIPTION
Fixes spurious errors during test builds.  I sometimes got the value 10 instead.

However, this variable does not seem to be used, so a better fix might be to remove it altogether?

And - is the value 6 what was intended?