### PR TITLE
Introduction of ‘rxtree’, output tree for reaction data

### DIFF
--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -46,6 +46,7 @@ public:
 	virtual ~ISSHistogrammer(){};
 	
 	void MakeHists();
+	void MakeTree();
 	void ResetHists();
 	unsigned long FillHists();
 	
@@ -57,10 +58,7 @@ public:
 	void SetPace4File( std::string input_file_name );
 	void ReadPace4File( std::string input_file_name );
 
-	inline void SetOutput( std::string output_file_name ){
-		output_file = new TFile( output_file_name.data(), "recreate" );
-		MakeHists();
-	};
+	void SetOutput( std::string output_file_name );
 	inline void CloseOutput(){
 		PurgeOutput();
 		output_file->Close();
@@ -187,8 +185,12 @@ private:
 	std::shared_ptr<ISSElumEvt> elum_evt;
 	std::shared_ptr<ISSZeroDegreeEvt> zd_evt;
 	
-	/// Output file
+	/// Output file and tree
 	TFile *output_file;
+	TTree *output_tree;
+	std::unique_ptr<ISSRxEvent> rx_evts; ///< Container for event-by-event reaction data
+	std::unique_ptr<ISSRxInfo> rx_info; ///< Container for reaction info (doesn't change for each event)
+
 	
 	// Progress bar
 	bool _prog_;

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -38,11 +38,6 @@
 #endif
 
 
-// Compiler switch for the pside only histogramming
-// uncomment the line below to ignore the p/n coincidences
-//#define pside_only
-
-
 class ISSHistogrammer {
 	
 public:

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -46,7 +46,6 @@ public:
 	virtual ~ISSHistogrammer(){};
 	
 	void MakeHists();
-	void MakeTree();
 	void ResetHists();
 	unsigned long FillHists();
 	

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -222,6 +222,8 @@ public:
 
 	inline unsigned char GetLaserMode(){ return laser_mode; }; ///< Getter for LaserMode value
 	
+	inline bool GetArrayHistMode(){ return array_hist_mode; }; ///< array mode, p-side only data or demand p/n coincidences
+	
 	inline double GetZmeasured(){ return z_meas; };///< Getter for the measured z (where the particle lands on the array)
 	inline double GetZprojected(){ return z; };///< Getter for the projected z (where the particle would intersect with the beam axis)
 	
@@ -404,6 +406,9 @@ private:
 								///< 1 = laser on NOT off
 								///< 2 = laser on OR off (default)
 
+	// Array mode - p-side only or demand p/n coincidence
+	bool array_hist_mode;
+	
 	// Coincidence windows
 	double array_recoil_prompt[2]; ///< Prompt time windows between recoil and array event
 	double array_recoil_random[2]; ///< Prompt time window between recoil and array event

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -206,7 +206,12 @@ public:
 	inline double GetELUMOuterRadius(){ return elum_rout; };	///< Getter for the ELUM outer radius
 	inline double GetELUMDeadlayer(){ return elum_deadlayer; };	///< Getter for the ELUM dead layer
 	inline double GetThetaCM(){ return Recoil.GetThetaCM(); };///< Getter for the CM angle of the recoil/ejectile
-	inline double GetDistance(){ return z; };///< Getter for the interaction point
+	inline double GetThetaLab(){ return Ejectile.GetThetaLab(); };///< Getter for the lab angle of the ejectile
+	inline double GetDistance(){ return z; };///< Getter for the z distance as ejectile returns to axis
+	inline double GetDistanceMeasured(){ return z_meas; };///< Getter for the z distance as the ejectile intercepts the detector
+	inline double GetPhi(){ return phi; };///< Getter for the phi angle as ejectile is emitted from the target
+	inline double GetPhiMeasured(){ return phi_meas; };///< Getter for the phi angle of the ejectile as it intercepts the detector
+	inline double GetRadiusMeasured(){ return r_meas; };///< Getter for the phi angle of the ejectile as it intercepts the detector
 	inline double GetEx(){ return Recoil.GetEx(); };///< Getter for the excitation energy
 
 	inline double GetOffsetX(){ return x_offset; };
@@ -223,7 +228,8 @@ public:
 	inline unsigned char GetLaserMode(){ return laser_mode; }; ///< Getter for LaserMode value
 	
 	inline bool GetArrayHistMode(){ return array_hist_mode; }; ///< array mode, p-side only data or demand p/n coincidences
-	
+	inline bool RxTreeEnabled(){ return rxtree_flag; }; ///< if the user output tree is enabled
+
 	inline double GetZmeasured(){ return z_meas; };///< Getter for the measured z (where the particle lands on the array)
 	inline double GetZprojected(){ return z; };///< Getter for the projected z (where the particle would intersect with the beam axis)
 	
@@ -409,6 +415,9 @@ private:
 	// Array mode - p-side only or demand p/n coincidence
 	bool array_hist_mode;
 	
+	// Flag for enabling the output tree
+	bool rxtree_flag;
+	
 	// Coincidence windows
 	double array_recoil_prompt[2]; ///< Prompt time windows between recoil and array event
 	double array_recoil_random[2]; ///< Prompt time window between recoil and array event
@@ -421,6 +430,8 @@ private:
 	double r_meas;		///< Measured radius of the ejectile when it interects the array
 	double z_meas;		///< Measured z distance from target that ejectile interesect the silicon detector
 	double z;			///< Projected z distance from target that ejectile interesect the beam axis
+	double phi_meas;	///< Measured phi angle that ejectile interesect the silicon detector
+	double phi;			///< Projected phi angle of the ejectile emitted from the target
 
 	// Target thickness and offsets
 	double target_thickness;	///< Target thickness in units of mg/cm^2
@@ -459,5 +470,73 @@ private:
 	bool flag_source;	///< Flag in case it's an alpha source run
 
 };
+
+class ISSRxEvent : public TObject {
+	
+public:
+	
+	ISSRxEvent() {}; ///< Constructor
+	~ISSRxEvent() {}; ///< Destructor
+	
+	// Set function
+	inline void SetRxEvent( std::shared_ptr<ISSReaction> react, double ebistime, double t1time, bool laserflag ){
+		theta_cm = react->GetThetaLab();
+		theta_lab = react->GetThetaCM();
+		z = react->GetDistance();
+		z_meas = react->GetDistanceMeasured();
+		phi = react->GetPhi();
+		phi_meas = react->GetPhiMeasured();
+		r_meas = react->GetRadiusMeasured();
+		Ex = react->GetEx();
+		Qvalue = react->GetQvalue();
+		gamma_ejectile = react->GetEjectile()->GetGamma();
+		beta_ejectile = react->GetEjectile()->GetBeta();
+		ebis_td = ebistime;
+		t1_td = t1time;
+		laser = laserflag;
+	};
+	
+private:
+	
+	// Members of the class
+	double theta_cm, theta_lab;
+	double z_meas, z, phi_meas, phi, r_meas;
+	double Ex, Qvalue;
+	double gamma_ejectile, beta_ejectile;
+	double ebis_td, t1_td;
+	bool laser;
+	
+	ClassDef( ISSRxEvent, 1 )
+	
+};
+
+
+class ISSRxInfo : public TObject {
+	
+public:
+	
+	ISSRxInfo() {}; ///< Constructor
+	~ISSRxInfo() {}; ///< Destructor
+	
+	// Set function
+	inline void SetRxInfo( std::shared_ptr<ISSReaction> react ){
+		Mfield = react->GetField();
+		Etot_lab = react->GetEnergyTotLab();
+		Etot_cm = react->GetEnergyTotCM();
+		gamma = react->GetGamma();
+		beta = react->GetBeta();
+	};
+	
+private:
+	
+	// Members of the class
+	double Mfield;
+	double Etot_lab, Etot_cm;
+	double gamma, beta;
+	
+	ClassDef( ISSRxInfo, 1 )
+	
+};
+
 
 #endif

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -479,7 +479,7 @@ public:
 	~ISSRxEvent() {}; ///< Destructor
 	
 	// Set function
-	inline void SetRxEvent( std::shared_ptr<ISSReaction> react, double ebistime, double t1time, bool laserflag ){
+	inline void SetRxEvent( std::shared_ptr<ISSReaction> react, double E, double ebistime, double t1time, bool laserflag ){
 		theta_cm = react->GetThetaLab();
 		theta_lab = react->GetThetaCM();
 		z = react->GetDistance();
@@ -487,6 +487,7 @@ public:
 		phi = react->GetPhi();
 		phi_meas = react->GetPhiMeasured();
 		r_meas = react->GetRadiusMeasured();
+		Edet = E;
 		Ex = react->GetEx();
 		Qvalue = react->GetQvalue();
 		gamma_ejectile = react->GetEjectile()->GetGamma();
@@ -501,7 +502,7 @@ private:
 	// Members of the class
 	double theta_cm, theta_lab;
 	double z_meas, z, phi_meas, phi, r_meas;
-	double Ex, Qvalue;
+	double Edet, Ex, Qvalue;
 	double gamma_ejectile, beta_ejectile;
 	double ebis_td, t1_td;
 	bool laser;

--- a/include/RootLinkDef.h
+++ b/include/RootLinkDef.h
@@ -28,6 +28,8 @@
 #pragma link C++ class ISSInfoData+;
 #pragma link C++ class ISSReaction+;
 #pragma link C++ class ISSParticle+;
+#pragma link C++ class ISSRxEvent+;
+#pragma link C++ class ISSRxInfo+;
 #pragma link C++ class ISSGUI;
 #pragma link C++ class ISSDialog;
 #endif

--- a/reaction.dat
+++ b/reaction.dat
@@ -1,17 +1,17 @@
-# Reaction file for ISSSort
-#
-# pass this file to iss_sort with the -r flag
-#
-# Liam Gaffney - July 2021
-# liam.gaffney@liverpool.ac.uk
-#
-# Below are the default parameters that can be changed by uncommenting
-# and passing this file to iss_sort during the histogramming stage.
-#
-# This file is not required to run iss_sort, but if you want meaningfull
-# physics histograms at the end, then you should change the parameters
-# here to match your experiment. One can have multiple versions of this
-# file to sort different runs or apply different recoil gates, etc.
+## Reaction file for ISSSort
+##
+## pass this file to iss_sort with the -r flag
+##
+## Liam Gaffney - July 2021
+## liam.gaffney@liverpool.ac.uk
+##
+## Below are the default parameters that can be changed by uncommenting
+## and passing this file to iss_sort during the histogramming stage.
+##
+## This file is not required to run iss_sort, but if you want meaningfull
+## physics histograms at the end, then you should change the parameters
+## here to match your experiment. One can have multiple versions of this
+## file to sort different runs or apply different recoil gates, etc.
 
 
 ## Reaction definition
@@ -38,34 +38,34 @@
 #TargetOffset.Y: 0.0	# Beam spot offset with respect to the horizontal in mm (positive is right wrt beam direction)
 
 
-# ELUM geometry
+## ELUM geometry
 #ELUM.Distance: -1.0		# Negative number means it doesn't exist by default (in mm)
 #ELUM.OuterRadius: 48.0		# outer radius of the ELUM detector (default for S1, in mm)
 #ELUM.InnerRadius: 24.0		# inner radius of the ELUM detector (default for S1, in mm)
 #ELUM.Deadlayer: 0.0004		# Dead layer on surface of the ELUM in mm of Al (0.4 µm from data sheets)
 
 
-# EBIS windows
+## EBIS windows
 #EBIS.On: 1.20e6		# slow extraction is about 1.2 ms
 #EBIS.Off: 2.52e7		# Off window is 20 times the On window
 #EBIS.FillRatio: 20		# Fill ratio for EBIS, default is ratio of time windows
 
-# T1 cut
+## T1 cut
 #T1.Min: 0			# for cutting on the proton impact time
 #T1.Max: 1.2e9		# (units of ns)
 
-# Laser mode ON/OFF
+## Laser mode ON/OFF
 #LaserMode: 2		# 0 = laser off only
 					# 1 = laser on only
 					# 2 = laser on OR off (default, i.e. all data)
 
-# Array-Recoil windows
+## Array-Recoil windows
 #ArrayRecoil_PromptTime.Min: -300
 #ArrayRecoil_PromptTime.Max: 300
 #ArrayRecoil_RandomTime.Min: 600
 #ArrayRecoil_RandomTime.Max: 1200
 
-# ELUM-Recoil windows
+## ELUM-Recoil windows
 #ElumRecoil_PromptTime.Min: -300
 #ElumRecoil_PromptTime.Max: 300
 #ElumRecoil_RandomTime.Min: 600

--- a/reaction.dat
+++ b/reaction.dat
@@ -88,5 +88,6 @@
 #EvsZCut_0.Name: CUTG		# name of the TCutG object inside the ROOT file
 
 
-# Histogramming options
-Hists.ArrayMode: 0			# 0 - demand p/n coincidences, 1 - p-side only
+## Histogramming options
+#Hists.ArrayMode: 0			# 0 - demand p/n coincidences, 1 - p-side only
+#Hists.OutputTree: 0			# 0 - off, 1 - reaction data output to tree

--- a/reaction.dat
+++ b/reaction.dat
@@ -86,3 +86,7 @@
 #NumberOfEvsZCuts: 1		# default is 1, but you can have as many as your RAM will handle
 #EvsZCut_0.File: NULL		# ROOT file containing the a 2D E vs Z cut
 #EvsZCut_0.Name: CUTG		# name of the TCutG object inside the ROOT file
+
+
+# Histogramming options
+Hists.ArrayMode: 0			# 0 - demand p/n coincidences, 1 - p-side only

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -316,7 +316,7 @@ void ISSEventBuilder::SetOutput( std::string output_file_name ) {
 	// --------------------------------------------------------- //
 	output_file = new TFile( output_file_name.data(), "recreate" );
 	output_tree = new TTree( "evt_tree", "evt_tree" );
-	output_tree->Branch( "ISSEvts", "ISSEvts", write_evts.get() );
+	output_tree->Branch( "ISSEvts", write_evts.get() );
 	output_tree->SetAutoFlush();
 
 	// Create log file.

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -311,9 +311,9 @@ void ISSEventBuilder::SetOutput( std::string output_file_name ) {
 	gamma_evt	= std::make_shared<ISSGammaRayEvt>();
 	lume_evt	= std::make_shared<ISSLumeEvt>();
 
-	// ------------------------------------------------------------------------ //
+	// --------------------------------------------------------- //
 	// Create output file and create events tree
-	// ------------------------------------------------------------------------ //
+	// --------------------------------------------------------- //
 	output_file = new TFile( output_file_name.data(), "recreate" );
 	output_tree = new TTree( "evt_tree", "evt_tree" );
 	output_tree->Branch( "ISSEvts", "ISSEvts", write_evts.get() );
@@ -324,7 +324,7 @@ void ISSEventBuilder::SetOutput( std::string output_file_name ) {
 	log_file_name += ".log";
 	log_file.open( log_file_name.data(), std::ios::app );
 	
-	// Hisograms in separate function
+	// Histograms in separate function
 	MakeHists();
 	
 }

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -14,6 +14,29 @@ ISSHistogrammer::ISSHistogrammer( std::shared_ptr<ISSReaction> myreact, std::sha
 	
 }
 
+void ISSHistogrammer::SetOutput( std::string output_file_name ){
+	
+	// These are the branches we need
+	rx_evts	= std::make_unique<ISSRxEvent>();
+	rx_info	= std::make_unique<ISSRxInfo>();
+
+	// --------------------------------------------------------- //
+	// Create output file and create reaction tree
+	// --------------------------------------------------------- //
+	output_file = new TFile( output_file_name.data(), "recreate" );
+	output_tree = new TTree( "rxtree", "Reaction data tree" );
+	output_tree->Branch( "RxEvent", "Reaction event", rx_evts.get() );
+	output_tree->Branch( "RxInfo", "Reaction information", rx_info.get() );
+	output_tree->SetAutoFlush();
+
+	// Setup the reaction info
+	rx_info->SetRxInfo( react );
+	
+	// Histograms in separate function
+	MakeHists();
+	
+}
+
 void ISSHistogrammer::MakeHists() {
 	
     std::string hname, htitle;
@@ -23,9 +46,9 @@ void ISSHistogrammer::MakeHists() {
 	double d0 = react->GetArrayDistance();
 	double d;
 	
-	for ( int row = 0; row < 4; row++ ){
+	for( int row = 0; row < 4; row++ ){
 		
-		for ( int ch = 0; ch < 128; ch++ ){
+		for( int ch = 0; ch < 128; ch++ ){
 			
 			// Get the info from the ISSEvt class
 			ISSArrayEvt tmp_evt;
@@ -1202,9 +1225,10 @@ void ISSHistogrammer::MakeHists() {
 		htitle = "ELUM singles for sector " + std::to_string(j);
 		htitle += " with a random time gate on all recoils;Energy [keV];Counts 5 keV";
 		elum_recoilT_random_sec[j] = new TH1F( hname.data(), htitle.data(), 10000, 0, 50000 );
-		
 
 	} // ELUM
+	
+	output_file->cd();
 	
 }
 
@@ -1704,7 +1728,7 @@ unsigned long ISSHistogrammer::FillHists() {
 		
 		// Loop over array events
 		for( unsigned int j = 0; j < array_mult; ++j ){
-
+			
 			// Get array event - GetArrayEvt is "normal" mode, GetArrayPEvt is p-side only
 			if( psideonly ) array_evt = read_evts->GetArrayPEvt(j);
 			else array_evt = read_evts->GetArrayEvt(j);
@@ -1712,6 +1736,24 @@ unsigned long ISSHistogrammer::FillHists() {
 			// Do the reaction
 			react->MakeReaction( array_evt->GetPosition(), array_evt->GetEnergy() );
 			
+			// Setup the output tree if user wants it
+			if( react->RxTreeEnabled() ) {
+				
+				// This is an array event after the reaction is calculated
+				rx_evts->SetRxEvent( react, array_evt->GetTime() - read_evts->GetEBIS(),
+									array_evt->GetTime() - read_evts->GetT1(),
+									read_evts->GetLaserStatus() );
+				
+				// Then fill the tree
+				output_tree->Fill();
+				
+				// Clean up if the next event is going to make the tree full
+				if( output_tree->MemoryFull(30e6) )
+					output_tree->DropBaskets();
+				
+			}
+
+
 			// Singles
 			E_vs_z->Fill( react->GetZmeasured(), array_evt->GetEnergy() );
 			E_vs_z_mod[array_evt->GetModule()]->Fill( react->GetZmeasured(), array_evt->GetEnergy() );
@@ -2245,10 +2287,12 @@ unsigned long ISSHistogrammer::FillHists() {
 			std::cout.flush();
 			
 		}
-		
+
 	} // all events
 	
-	output_file->Write();
+	// Force the rest of the events in the buffer to disk
+	output_tree->FlushBaskets();
+	output_file->Write( 0, TObject::kWriteDelete );
 	
 	return n_entries;
 	

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -25,8 +25,8 @@ void ISSHistogrammer::SetOutput( std::string output_file_name ){
 	// --------------------------------------------------------- //
 	output_file = new TFile( output_file_name.data(), "recreate" );
 	output_tree = new TTree( "rxtree", "Reaction data tree" );
-	output_tree->Branch( "ISSRxEvent", "Reaction event", rx_evts.get() );
-	output_tree->Branch( "ISSRxInfo", "Reaction information", rx_info.get() );
+	output_tree->Branch( "RxEvent", rx_evts.get() );
+	output_tree->Branch( "RxInfo", rx_info.get() );
 	output_tree->SetAutoFlush();
 
 	// Setup the reaction info
@@ -1740,7 +1740,8 @@ unsigned long ISSHistogrammer::FillHists() {
 			if( react->RxTreeEnabled() ) {
 				
 				// This is an array event after the reaction is calculated
-				rx_evts->SetRxEvent( react, array_evt->GetTime() - read_evts->GetEBIS(),
+				rx_evts->SetRxEvent( react, array_evt->GetEnergy(),
+									array_evt->GetTime() - read_evts->GetEBIS(),
 									array_evt->GetTime() - read_evts->GetT1(),
 									read_evts->GetLaserStatus() );
 				

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -25,8 +25,8 @@ void ISSHistogrammer::SetOutput( std::string output_file_name ){
 	// --------------------------------------------------------- //
 	output_file = new TFile( output_file_name.data(), "recreate" );
 	output_tree = new TTree( "rxtree", "Reaction data tree" );
-	output_tree->Branch( "RxEvent", "Reaction event", rx_evts.get() );
-	output_tree->Branch( "RxInfo", "Reaction information", rx_info.get() );
+	output_tree->Branch( "ISSRxEvent", "Reaction event", rx_evts.get() );
+	output_tree->Branch( "ISSRxInfo", "Reaction information", rx_info.get() );
 	output_tree->SetAutoFlush();
 
 	// Setup the reaction info

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1697,21 +1697,18 @@ unsigned long ISSHistogrammer::FillHists() {
 		// tdiff variable
 		double tdiff;
 		
+		// Check the array mode, if we have p-side only or not
+		bool psideonly = react->GetArrayHistMode();
+		unsigned int array_mult = read_evts->GetArrayMultiplicity();
+		if( psideonly ) array_mult = read_evts->GetArrayPMultiplicity();
+		
 		// Loop over array events
-#ifdef pside_only
-		// if you want the p-side only events, use GetArrayPMultiplicity
-		for( unsigned int j = 0; j < read_evts->GetArrayPMultiplicity(); ++j ){
+		for( unsigned int j = 0; j < array_mult; ++j ){
+
+			// Get array event - GetArrayEvt is "normal" mode, GetArrayPEvt is p-side only
+			if( psideonly ) array_evt = read_evts->GetArrayPEvt(j);
+			else array_evt = read_evts->GetArrayEvt(j);
 			
-			// Get array event - GetArrayPEvt is p-side only events
-			array_evt = read_evts->GetArrayPEvt(j);
-#else
-		// if you want the "normal" mode using p/n-coincidences, use GetArrayMultiplicity
-		for( unsigned int j = 0; j < read_evts->GetArrayMultiplicity(); ++j ){
-
-			// Get array event - GetArrayEvt is "normal" mode
-			array_evt = read_evts->GetArrayEvt(j);
-#endif
-
 			// Do the reaction
 			react->MakeReaction( array_evt->GetPosition(), array_evt->GetEnergy() );
 			


### PR DESCRIPTION
Inspired by Han’s’ submission in #46 and now that I finally had a free afternoon to look at this, I have implemented the output tree requested by users in the summer.

This is very similar to the ‘rxtree’ by Hans, but the branches are a couple of new classes that contain the required variables, rather than one branch for each of the individual values. 

I might still be missing a couple of variables from the list. I missed out the time windows, because I guess if somebody is analysing from the tree, they’ll be making their own conditions on things like time. 

I need to think of a way to add the recoil data next, which is a bit tricky as there can be multiple recoils in an event. There’s a precedent for resolving this though, by adding a vector of events. Then we have to trust users to handle this correctly and not make any doubling counting (like I did originally in the histogrammer). 

Co-authored-by: Hans Toshihide Törnqvist <hanstt@github.com>