### PR TITLE
Update to reaction tree and phi angle calculations

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,0 +1,22 @@
+name: Doxygen GitHub Pages Deploy Action
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "main" ]
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: docs/html
+          config_file: Doxyfile
+          doxygen_version: 1.11.0

--- a/Doxyfile.bak
+++ b/Doxyfile.bak
@@ -1,4 +1,4 @@
-# Doxyfile 1.11.0
+# Doxyfile 1.9.5
 
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
@@ -19,8 +19,7 @@
 # configuration file:
 # doxygen -x [configFile]
 # Use doxygen to compare the used configuration file with the template
-# configuration file without replacing the environment variables or CMake type
-# replacement variables:
+# configuration file without replacing the environment variables:
 # doxygen -x_noenv [configFile]
 
 #---------------------------------------------------------------------------
@@ -63,18 +62,12 @@ PROJECT_BRIEF          =
 
 PROJECT_LOGO           = .isssort_logo.png
 
-# With the PROJECT_ICON tag one can specify an icon that is included in the tabs
-# when the HTML document is shown. Doxygen will copy the logo to the output
-# directory.
-
-PROJECT_ICON           = .isssort_logo.png
-
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docs
+OUTPUT_DIRECTORY       = doc
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format
@@ -92,7 +85,7 @@ CREATE_SUBDIRS         = NO
 # level increment doubles the number of directories, resulting in 4096
 # directories at level 8 which is the default and also the maximum value. The
 # sub-directories are organized in 2 levels, the first level always has a fixed
-# number of 16 directories.
+# numer of 16 directories.
 # Minimum value: 0, maximum value: 8, default value: 8.
 # This tag requires that the tag CREATE_SUBDIRS is set to YES.
 
@@ -364,21 +357,10 @@ MARKDOWN_SUPPORT       = YES
 # to that level are automatically included in the table of contents, even if
 # they do not have an id attribute.
 # Note: This feature currently applies only to Markdown headings.
-# Minimum value: 0, maximum value: 99, default value: 6.
+# Minimum value: 0, maximum value: 99, default value: 5.
 # This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
 
-TOC_INCLUDE_HEADINGS   = 6
-
-# The MARKDOWN_ID_STYLE tag can be used to specify the algorithm used to
-# generate identifiers for the Markdown headings. Note: Every identifier is
-# unique.
-# Possible values are: DOXYGEN use a fixed 'autotoc_md' string followed by a
-# sequence number starting at 0 and GITHUB use the lower case version of title
-# with any whitespace replaced by '-' and punctuation characters removed.
-# The default value is: DOXYGEN.
-# This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
-
-MARKDOWN_ID_STYLE      = DOXYGEN
+TOC_INCLUDE_HEADINGS   = 5
 
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can
@@ -392,8 +374,8 @@ AUTOLINK_SUPPORT       = YES
 # to include (a tag file for) the STL sources as input, then you should set this
 # tag to YES in order to let doxygen match functions declarations and
 # definitions whose arguments contain STL classes (e.g. func(std::string);
-# versus func(std::string) {}). This also makes the inheritance and
-# collaboration diagrams that involve STL classes more complete and accurate.
+# versus func(std::string) {}). This also make the inheritance and collaboration
+# diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
 BUILTIN_STL_SUPPORT    = NO
@@ -405,9 +387,9 @@ BUILTIN_STL_SUPPORT    = NO
 CPP_CLI_SUPPORT        = NO
 
 # Set the SIP_SUPPORT tag to YES if your project consists of sip (see:
-# https://www.riverbankcomputing.com/software) sources only. Doxygen will parse
-# them like normal C++ but will assume all classes use public instead of private
-# inheritance when no explicit protection keyword is present.
+# https://www.riverbankcomputing.com/software/sip/intro) sources only. Doxygen
+# will parse them like normal C++ but will assume all classes use public instead
+# of private inheritance when no explicit protection keyword is present.
 # The default value is: NO.
 
 SIP_SUPPORT            = NO
@@ -504,14 +486,6 @@ LOOKUP_CACHE_SIZE      = 0
 
 NUM_PROC_THREADS       = 1
 
-# If the TIMESTAMP tag is set different from NO then each generated page will
-# contain the date or date and time when the page was generated. Setting this to
-# NO can help when comparing the output of multiple runs.
-# Possible values are: YES, NO, DATETIME and DATE.
-# The default value is: NO.
-
-TIMESTAMP              = NO
-
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
@@ -593,8 +567,7 @@ HIDE_UNDOC_MEMBERS     = NO
 # If the HIDE_UNDOC_CLASSES tag is set to YES, doxygen will hide all
 # undocumented classes that are normally visible in the class hierarchy. If set
 # to NO, these classes will be included in the various overviews. This option
-# will also hide undocumented C++ concepts if enabled. This option has no effect
-# if EXTRACT_ALL is enabled.
+# has no effect if EXTRACT_ALL is enabled.
 # The default value is: NO.
 
 HIDE_UNDOC_CLASSES     = NO
@@ -632,8 +605,7 @@ INTERNAL_DOCS          = NO
 # Windows (including Cygwin) and MacOS, users should typically set this option
 # to NO, whereas on Linux or other Unix flavors it should typically be set to
 # YES.
-# Possible values are: SYSTEM, NO and YES.
-# The default value is: SYSTEM.
+# The default value is: system dependent.
 
 CASE_SENSE_NAMES       = YES
 
@@ -885,26 +857,11 @@ WARN_IF_INCOMPLETE_DOC = YES
 
 WARN_NO_PARAMDOC       = NO
 
-# If WARN_IF_UNDOC_ENUM_VAL option is set to YES, doxygen will warn about
-# undocumented enumeration values. If set to NO, doxygen will accept
-# undocumented enumeration values. If EXTRACT_ALL is set to YES then this flag
-# will automatically be disabled.
-# The default value is: NO.
-
-WARN_IF_UNDOC_ENUM_VAL = NO
-
 # If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
 # a warning is encountered. If the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS
 # then doxygen will continue running as if WARN_AS_ERROR tag is set to NO, but
 # at the end of the doxygen process doxygen will return with a non-zero status.
-# If the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS_PRINT then doxygen behaves
-# like FAIL_ON_WARNINGS but in case no WARN_LOGFILE is defined doxygen will not
-# write the warning messages in between other messages but write them at the end
-# of a run, in case a WARN_LOGFILE is defined the warning messages will be
-# besides being in the defined file also be shown at the end of a run, unless
-# the WARN_LOGFILE is defined as - i.e. standard output (stdout) in that case
-# the behavior will remain as with the setting FAIL_ON_WARNINGS.
-# Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
+# Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
 WARN_AS_ERROR          = NO
@@ -956,20 +913,9 @@ INPUT                  = README.md src include iss_sort.cc utils *dat
 # libiconv (or the iconv built into libc) for the transcoding. See the libiconv
 # documentation (see:
 # https://www.gnu.org/software/libiconv/) for the list of possible encodings.
-# See also: INPUT_FILE_ENCODING
 # The default value is: UTF-8.
 
 INPUT_ENCODING         = UTF-8
-
-# This tag can be used to specify the character encoding of the source files
-# that doxygen parses The INPUT_FILE_ENCODING tag can be used to specify
-# character encoding on a per file pattern basis. Doxygen will compare the file
-# name with each pattern and apply the encoding instead of the default
-# INPUT_ENCODING) if there is a match. The character encodings are a list of the
-# form: pattern=encoding (like *.php=ISO-8859-1).
-# See also: INPUT_ENCODING for further information on supported encodings.
-
-INPUT_FILE_ENCODING    =
 
 # If the value of the INPUT tag contains directories, you can use the
 # FILE_PATTERNS tag to specify one or more wildcard patterns (like *.cpp and
@@ -982,22 +928,18 @@ INPUT_FILE_ENCODING    =
 # Note the list of default checked file patterns might differ from the list of
 # default file extension mappings.
 #
-# If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cxxm,
-# *.cpp, *.cppm, *.ccm, *.c++, *.c++m, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl,
-# *.idl, *.ddl, *.odl, *.h, *.hh, *.hxx, *.hpp, *.h++, *.ixx, *.l, *.cs, *.d,
-# *.php, *.php4, *.php5, *.phtml, *.inc, *.m, *.markdown, *.md, *.mm, *.dox (to
-# be provided as doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
-# *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
+# If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cpp,
+# *.c++, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h,
+# *.hh, *.hxx, *.hpp, *.h++, *.l, *.cs, *.d, *.php, *.php4, *.php5, *.phtml,
+# *.inc, *.m, *.markdown, *.md, *.mm, *.dox (to be provided as doxygen C
+# comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08, *.f18, *.f, *.for, *.vhd,
+# *.vhdl, *.ucf, *.qsf and *.ice.
 
 FILE_PATTERNS          = *.c \
                          *.cc \
                          *.cxx \
-                         *.cxxm \
                          *.cpp \
-                         *.cppm \
-                         *.ccm \
                          *.c++ \
-                         *.c++m \
                          *.java \
                          *.ii \
                          *.ixx \
@@ -1012,7 +954,6 @@ FILE_PATTERNS          = *.c \
                          *.hxx \
                          *.hpp \
                          *.h++ \
-                         *.ixx \
                          *.l \
                          *.cs \
                          *.d \
@@ -1077,6 +1018,9 @@ EXCLUDE_PATTERNS       =
 # output. The symbol name can be a fully qualified name, a word, or if the
 # wildcard * is used, a substring. Examples: ANamespace, AClass,
 # ANamespace::AClass, ANamespace::*Test
+#
+# Note that the wildcards are matched against the file with absolute path, so to
+# exclude all test directories use the pattern */test/*
 
 EXCLUDE_SYMBOLS        =
 
@@ -1120,11 +1064,6 @@ IMAGE_PATH             =
 # Note that the filter must not add or remove lines; it is applied before the
 # code is scanned, but not when the output code is generated. If lines are added
 # or removed, the anchors will not be placed correctly.
-#
-# Note that doxygen will use the data processed and written to standard output
-# for further processing, therefore nothing else, like debug statements or used
-# commands (so in case of a Windows batch file always use @echo OFF), should be
-# written to standard output.
 #
 # Note that for custom extensions or not directly supported extensions you also
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
@@ -1190,8 +1129,7 @@ FORTRAN_COMMENT_AFTER  = 72
 SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
-# multi-line macros, enums or list initialized variables directly into the
-# documentation.
+# classes and enums directly into the documentation.
 # The default value is: NO.
 
 INLINE_SOURCES         = NO
@@ -1274,11 +1212,10 @@ VERBATIM_HEADERS       = YES
 
 ALPHABETICAL_INDEX     = YES
 
-# The IGNORE_PREFIX tag can be used to specify a prefix (or a list of prefixes)
-# that should be ignored while generating the index headers. The IGNORE_PREFIX
-# tag works for classes, function and member names. The entity will be placed in
-# the alphabetical list under the first letter of the entity name that remains
-# after removing the prefix.
+# In case all classes in a project start with a common prefix, all classes will
+# be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
+# can be used to specify a prefix (or a list of prefixes) that should be ignored
+# while generating the index headers.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
 
 IGNORE_PREFIX          =
@@ -1357,12 +1294,7 @@ HTML_STYLESHEET        =
 # Doxygen will copy the style sheet files to the output directory.
 # Note: The order of the extra style sheet files is of importance (e.g. the last
 # style sheet in the list overrules the setting of the previous ones in the
-# list).
-# Note: Since the styling of scrollbars can currently not be overruled in
-# Webkit/Chromium, the styling will be left out of the default doxygen.css if
-# one or more extra stylesheets have been specified. So if scrollbar
-# customization is desired it has to be added explicitly. For an example see the
-# documentation.
+# list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 HTML_EXTRA_STYLESHEET  =
@@ -1376,19 +1308,6 @@ HTML_EXTRA_STYLESHEET  =
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 HTML_EXTRA_FILES       =
-
-# The HTML_COLORSTYLE tag can be used to specify if the generated HTML output
-# should be rendered with a dark or light theme.
-# Possible values are: LIGHT always generates light mode output, DARK always
-# generates dark mode output, AUTO_LIGHT automatically sets the mode according
-# to the user preference, uses light mode if no preference is set (the default),
-# AUTO_DARK automatically sets the mode according to the user preference, uses
-# dark mode if no preference is set and TOGGLE allows a user to switch between
-# light and dark mode via a button.
-# The default value is: AUTO_LIGHT.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_COLORSTYLE        = AUTO_LIGHT
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to
@@ -1420,6 +1339,15 @@ HTML_COLORSTYLE_SAT    = 100
 
 HTML_COLORSTYLE_GAMMA  = 80
 
+# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
+# page will contain the date and time when the page was generated. Setting this
+# to YES can help to show when doxygen was last run and thus if the
+# documentation is up to date.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_TIMESTAMP         = YES
+
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
 # are dynamically created via JavaScript. If disabled, the navigation index will
@@ -1438,33 +1366,6 @@ HTML_DYNAMIC_MENUS     = YES
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 HTML_DYNAMIC_SECTIONS  = NO
-
-# If the HTML_CODE_FOLDING tag is set to YES then classes and functions can be
-# dynamically folded and expanded in the generated HTML source code.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_CODE_FOLDING      = YES
-
-# If the HTML_COPY_CLIPBOARD tag is set to YES then doxygen will show an icon in
-# the top right corner of code and text fragments that allows the user to copy
-# its content to the clipboard. Note this only works if supported by the browser
-# and the web page is served via a secure context (see:
-# https://www.w3.org/TR/secure-contexts/), i.e. using the https: or file:
-# protocol.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_COPY_CLIPBOARD    = YES
-
-# Doxygen stores a couple of settings persistently in the browser (via e.g.
-# cookies). By default these settings apply to all HTML pages generated by
-# doxygen across all projects. The HTML_PROJECT_COOKIE tag can be used to store
-# the settings under a project specific key, such that the user preferences will
-# be stored separately.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_PROJECT_COOKIE    =
 
 # With HTML_INDEX_NUM_ENTRIES one can control the preferred number of entries
 # shown in the various tree structured indices initially; the user can expand
@@ -1595,16 +1496,6 @@ BINARY_TOC             = NO
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
 TOC_EXPAND             = NO
-
-# The SITEMAP_URL tag is used to specify the full URL of the place where the
-# generated documentation will be placed on the server by the user during the
-# deployment of the documentation. The generated sitemap is called sitemap.xml
-# and placed on the directory specified by HTML_OUTPUT. In case no SITEMAP_URL
-# is specified no sitemap is generated. For information about the sitemap
-# protocol see https://www.sitemaps.org
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-SITEMAP_URL            =
 
 # If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
 # QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that
@@ -1781,6 +1672,17 @@ HTML_FORMULA_FORMAT    = png
 
 FORMULA_FONTSIZE       = 10
 
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
+# generated for formulas are transparent PNGs. Transparent PNGs are not
+# supported properly for IE 6.0, but are supported on all modern browsers.
+#
+# Note that when changing this option you need to delete any form_*.png files in
+# the HTML output directory before the changes have effect.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+FORMULA_TRANSPARENT    = YES
+
 # The FORMULA_MACROFILE can contain LaTeX \newcommand and \renewcommand commands
 # to create new LaTeX commands to be used in formulas as building blocks. See
 # the section "Including formulas" for details.
@@ -1818,7 +1720,7 @@ MATHJAX_VERSION        = MathJax_2
 # Possible values are: HTML-CSS (which is slower, but has the best
 # compatibility. This is the name for Mathjax version 2, for MathJax version 3
 # this will be translated into chtml), NativeMML (i.e. MathML. Only supported
-# for MathJax 2. For MathJax version 3 chtml will be used instead.), chtml (This
+# for NathJax 2. For MathJax version 3 chtml will be used instead.), chtml (This
 # is the name for Mathjax version 3, for MathJax version 2 this will be
 # translated into HTML-CSS) and SVG.
 # The default value is: HTML-CSS.
@@ -1842,8 +1744,8 @@ MATHJAX_RELPATH        =
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example
-# for MathJax version 2 (see
-# https://docs.mathjax.org/en/v2.7-latest/tex.html#tex-and-latex-extensions):
+# for MathJax version 2 (see https://docs.mathjax.org/en/v2.7-latest/tex.html
+# #tex-and-latex-extensions):
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # For example for MathJax version 3 (see
 # http://docs.mathjax.org/en/latest/input/tex/extensions/index.html):
@@ -1956,7 +1858,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2094,16 +1996,9 @@ PDF_HYPERLINKS         = YES
 
 USE_PDFLATEX           = YES
 
-# The LATEX_BATCHMODE tag signals the behavior of LaTeX in case of an error.
-# Possible values are: NO same as ERROR_STOP, YES same as BATCH, BATCH In batch
-# mode nothing is printed on the terminal, errors are scrolled as if <return> is
-# hit at every error; missing files that TeX tries to input or request from
-# keyboard input (\read on a not open input stream) cause the job to abort,
-# NON_STOP In nonstop mode the diagnostic message will appear on the terminal,
-# but there is no possibility of user interaction just like in batch mode,
-# SCROLL In scroll mode, TeX will stop only for missing files to input or if
-# keyboard input is necessary and ERROR_STOP In errorstop mode, TeX will stop at
-# each error, asking for user intervention.
+# If the LATEX_BATCHMODE tag is set to YES, doxygen will add the \batchmode
+# command to the generated LaTeX files. This will instruct LaTeX to keep running
+# if errors occur, instead of asking the user for help.
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
@@ -2123,6 +2018,14 @@ LATEX_HIDE_INDICES     = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
+
+# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
+# page will contain the date and time when the page was generated. Setting this
+# to NO can help when comparing the output of multiple runs.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_LATEX is set to YES.
+
+LATEX_TIMESTAMP        = NO
 
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,
@@ -2187,14 +2090,6 @@ RTF_STYLESHEET_FILE    =
 # This tag requires that the tag GENERATE_RTF is set to YES.
 
 RTF_EXTENSIONS_FILE    =
-
-# The RTF_EXTRA_FILES tag can be used to specify one or more extra images or
-# other source files which should be copied to the RTF_OUTPUT output directory.
-# Note that the files will be copied as-is; there are no commands or markers
-# available.
-# This tag requires that the tag GENERATE_RTF is set to YES.
-
-RTF_EXTRA_FILES        =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the man page output
@@ -2297,38 +2192,12 @@ DOCBOOK_OUTPUT         = docbook
 #---------------------------------------------------------------------------
 
 # If the GENERATE_AUTOGEN_DEF tag is set to YES, doxygen will generate an
-# AutoGen Definitions (see https://autogen.sourceforge.net/) file that captures
+# AutoGen Definitions (see http://autogen.sourceforge.net/) file that captures
 # the structure of the code including all documentation. Note that this feature
 # is still experimental and incomplete at the moment.
 # The default value is: NO.
 
 GENERATE_AUTOGEN_DEF   = NO
-
-#---------------------------------------------------------------------------
-# Configuration options related to Sqlite3 output
-#---------------------------------------------------------------------------
-
-# If the GENERATE_SQLITE3 tag is set to YES doxygen will generate a Sqlite3
-# database with symbols found by doxygen stored in tables.
-# The default value is: NO.
-
-GENERATE_SQLITE3       = NO
-
-# The SQLITE3_OUTPUT tag is used to specify where the Sqlite3 database will be
-# put. If a relative path is entered the value of OUTPUT_DIRECTORY will be put
-# in front of it.
-# The default directory is: sqlite3.
-# This tag requires that the tag GENERATE_SQLITE3 is set to YES.
-
-SQLITE3_OUTPUT         = sqlite3
-
-# The SQLITE3_RECREATE_DB tag is set to YES, the existing doxygen_sqlite3.db
-# database file will be recreated with each doxygen run. If set to NO, doxygen
-# will warn if a database file is already found and not modify it.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_SQLITE3 is set to YES.
-
-SQLITE3_RECREATE_DB    = YES
 
 #---------------------------------------------------------------------------
 # Configuration options related to the Perl module output
@@ -2472,15 +2341,15 @@ TAGFILES               =
 
 GENERATE_TAGFILE       =
 
-# If the ALLEXTERNALS tag is set to YES, all external classes and namespaces
-# will be listed in the class and namespace index. If set to NO, only the
-# inherited external classes will be listed.
+# If the ALLEXTERNALS tag is set to YES, all external class will be listed in
+# the class index. If set to NO, only the inherited external classes will be
+# listed.
 # The default value is: NO.
 
 ALLEXTERNALS           = NO
 
 # If the EXTERNAL_GROUPS tag is set to YES, all external groups will be listed
-# in the topic index. If set to NO, only the current project's groups will be
+# in the modules index. If set to NO, only the current project's groups will be
 # listed.
 # The default value is: YES.
 
@@ -2494,8 +2363,15 @@ EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES
 
 #---------------------------------------------------------------------------
-# Configuration options related to diagram generator tools
+# Configuration options related to the dot tool
 #---------------------------------------------------------------------------
+
+# You can include diagrams made with dia in doxygen documentation. Doxygen will
+# then run dia to produce the diagram and insert it in the documentation. The
+# DIA_PATH tag allows you to specify the directory where the dia binary resides.
+# If left empty dia is assumed to be found in the default search path.
+
+DIA_PATH               =
 
 # If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.
@@ -2505,7 +2381,7 @@ HIDE_UNDOC_RELATIONS   = YES
 
 # If you set the HAVE_DOT tag to YES then doxygen will assume the dot tool is
 # available from the path. This tool is part of Graphviz (see:
-# https://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
+# http://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
 # Bell Labs. The other options in this section have no effect if this option is
 # set to NO
 # The default value is: NO.
@@ -2522,55 +2398,37 @@ HAVE_DOT               = NO
 
 DOT_NUM_THREADS        = 0
 
-# DOT_COMMON_ATTR is common attributes for nodes, edges and labels of
-# subgraphs. When you want a differently looking font in the dot files that
-# doxygen generates you can specify fontname, fontcolor and fontsize attributes.
-# For details please see <a href=https://graphviz.org/doc/info/attrs.html>Node,
-# Edge and Graph Attributes specification</a> You need to make sure dot is able
-# to find the font, which can be done by putting it in a standard location or by
-# setting the DOTFONTPATH environment variable or by setting DOT_FONTPATH to the
-# directory containing the font. Default graphviz fontsize is 14.
-# The default value is: fontname=Helvetica,fontsize=10.
+# When you want a differently looking font in the dot files that doxygen
+# generates you can specify the font name using DOT_FONTNAME. You need to make
+# sure dot is able to find the font, which can be done by putting it in a
+# standard location or by setting the DOTFONTPATH environment variable or by
+# setting DOT_FONTPATH to the directory containing the font.
+# The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_COMMON_ATTR        = "fontname=Helvetica,fontsize=10"
+DOT_FONTNAME           = Helvetica
 
-# DOT_EDGE_ATTR is concatenated with DOT_COMMON_ATTR. For elegant style you can
-# add 'arrowhead=open, arrowtail=open, arrowsize=0.5'. <a
-# href=https://graphviz.org/doc/info/arrows.html>Complete documentation about
-# arrows shapes.</a>
-# The default value is: labelfontname=Helvetica,labelfontsize=10.
+# The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
+# dot graphs.
+# Minimum value: 4, maximum value: 24, default value: 10.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_EDGE_ATTR          = "labelfontname=Helvetica,labelfontsize=10"
+DOT_FONTSIZE           = 10
 
-# DOT_NODE_ATTR is concatenated with DOT_COMMON_ATTR. For view without boxes
-# around nodes set 'shape=plain' or 'shape=plaintext' <a
-# href=https://www.graphviz.org/doc/info/shapes.html>Shapes specification</a>
-# The default value is: shape=box,height=0.2,width=0.4.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_NODE_ATTR          = "shape=box,height=0.2,width=0.4"
-
-# You can set the path where dot can find font specified with fontname in
-# DOT_COMMON_ATTR and others dot attributes.
+# By default doxygen will tell dot to use the default font as specified with
+# DOT_FONTNAME. If you specify a different font using DOT_FONTNAME you can set
+# the path where dot can find it using this tag.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 DOT_FONTPATH           =
 
-# If the CLASS_GRAPH tag is set to YES or GRAPH or BUILTIN then doxygen will
-# generate a graph for each documented class showing the direct and indirect
-# inheritance relations. In case the CLASS_GRAPH tag is set to YES or GRAPH and
-# HAVE_DOT is enabled as well, then dot will be used to draw the graph. In case
-# the CLASS_GRAPH tag is set to YES and HAVE_DOT is disabled or if the
-# CLASS_GRAPH tag is set to BUILTIN, then the built-in generator will be used.
-# If the CLASS_GRAPH tag is set to TEXT the direct and indirect inheritance
-# relations will be shown as texts / links. Explicit enabling an inheritance
-# graph or choosing a different representation for an inheritance graph of a
-# specific class, can be accomplished by means of the command \inheritancegraph.
-# Disabling an inheritance graph can be accomplished by means of the command
-# \hideinheritancegraph.
-# Possible values are: NO, YES, TEXT, GRAPH and BUILTIN.
+# If the CLASS_GRAPH tag is set to YES (or GRAPH) then doxygen will generate a
+# graph for each documented class showing the direct and indirect inheritance
+# relations. In case HAVE_DOT is set as well dot will be used to draw the graph,
+# otherwise the built-in generator will be used. If the CLASS_GRAPH tag is set
+# to TEXT the direct and indirect inheritance relations will be shown as texts /
+# links.
+# Possible values are: NO, YES, TEXT and GRAPH.
 # The default value is: YES.
 
 CLASS_GRAPH            = YES
@@ -2578,21 +2436,15 @@ CLASS_GRAPH            = YES
 # If the COLLABORATION_GRAPH tag is set to YES then doxygen will generate a
 # graph for each documented class showing the direct and indirect implementation
 # dependencies (inheritance, containment, and class references variables) of the
-# class with other documented classes. Explicit enabling a collaboration graph,
-# when COLLABORATION_GRAPH is set to NO, can be accomplished by means of the
-# command \collaborationgraph. Disabling a collaboration graph can be
-# accomplished by means of the command \hidecollaborationgraph.
+# class with other documented classes.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 COLLABORATION_GRAPH    = YES
 
 # If the GROUP_GRAPHS tag is set to YES then doxygen will generate a graph for
-# groups, showing the direct groups dependencies. Explicit enabling a group
-# dependency graph, when GROUP_GRAPHS is set to NO, can be accomplished by means
-# of the command \groupgraph. Disabling a directory graph can be accomplished by
-# means of the command \hidegroupgraph. See also the chapter Grouping in the
-# manual.
+# groups, showing the direct groups dependencies. See also the chapter Grouping
+# in the manual.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2634,8 +2486,8 @@ DOT_UML_DETAILS        = NO
 
 # The DOT_WRAP_THRESHOLD tag can be used to set the maximum number of characters
 # to display on a single line. If the actual line length exceeds this threshold
-# significantly it will be wrapped across multiple lines. Some heuristics are
-# applied to avoid ugly line breaks.
+# significantly it will wrapped across multiple lines. Some heuristics are apply
+# to avoid ugly line breaks.
 # Minimum value: 0, maximum value: 1000, default value: 17.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2652,9 +2504,7 @@ TEMPLATE_RELATIONS     = NO
 # If the INCLUDE_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are set to
 # YES then doxygen will generate a graph for each documented file showing the
 # direct and indirect include dependencies of the file with other documented
-# files. Explicit enabling an include graph, when INCLUDE_GRAPH is is set to NO,
-# can be accomplished by means of the command \includegraph. Disabling an
-# include graph can be accomplished by means of the command \hideincludegraph.
+# files.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2663,10 +2513,7 @@ INCLUDE_GRAPH          = YES
 # If the INCLUDED_BY_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are
 # set to YES then doxygen will generate a graph for each documented file showing
 # the direct and indirect include dependencies of the file with other documented
-# files. Explicit enabling an included by graph, when INCLUDED_BY_GRAPH is set
-# to NO, can be accomplished by means of the command \includedbygraph. Disabling
-# an included by graph can be accomplished by means of the command
-# \hideincludedbygraph.
+# files.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2706,10 +2553,7 @@ GRAPHICAL_HIERARCHY    = YES
 # If the DIRECTORY_GRAPH tag is set to YES then doxygen will show the
 # dependencies a directory has on other directories in a graphical way. The
 # dependency relations are determined by the #include relations between the
-# files in the directories. Explicit enabling a directory graph, when
-# DIRECTORY_GRAPH is set to NO, can be accomplished by means of the command
-# \directorygraph. Disabling a directory graph can be accomplished by means of
-# the command \hidedirectorygraph.
+# files in the directories.
 # The default value is: YES.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
@@ -2725,7 +2569,7 @@ DIR_GRAPH_MAX_DEPTH    = 1
 # The DOT_IMAGE_FORMAT tag can be used to set the image format of the images
 # generated by dot. For an explanation of the image formats see the section
 # output formats in the documentation of the dot tool (Graphviz (see:
-# https://www.graphviz.org/)).
+# http://www.graphviz.org/)).
 # Note: If you choose svg you need to set HTML_FILE_EXTENSION to xhtml in order
 # to make the SVG files visible in IE 9+ (other browsers do not have this
 # requirement).
@@ -2762,12 +2606,11 @@ DOT_PATH               =
 
 DOTFILE_DIRS           =
 
-# You can include diagrams made with dia in doxygen documentation. Doxygen will
-# then run dia to produce the diagram and insert it in the documentation. The
-# DIA_PATH tag allows you to specify the directory where the dia binary resides.
-# If left empty dia is assumed to be found in the default search path.
+# The MSCFILE_DIRS tag can be used to specify one or more directories that
+# contain msc files that are included in the documentation (see the \mscfile
+# command).
 
-DIA_PATH               =
+MSCFILE_DIRS           =
 
 # The DIAFILE_DIRS tag can be used to specify one or more directories that
 # contain dia files that are included in the documentation (see the \diafile
@@ -2796,7 +2639,7 @@ PLANTUML_INCLUDE_PATH  =
 # The DOT_GRAPH_MAX_NODES tag can be used to set the maximum number of nodes
 # that will be shown in the graph. If the number of nodes in a graph becomes
 # larger than this value, doxygen will truncate the graph, which is visualized
-# by representing a node as a red box. Note that if the number of direct
+# by representing a node as a red box. Note that doxygen if the number of direct
 # children of the root node in a graph is already larger than
 # DOT_GRAPH_MAX_NODES then the graph will not be shown at all. Also note that
 # the size of a graph can be further restricted by MAX_DOT_GRAPH_DEPTH.
@@ -2816,6 +2659,18 @@ DOT_GRAPH_MAX_NODES    = 50
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
+
+# Set the DOT_TRANSPARENT tag to YES to generate images with a transparent
+# background. This is disabled by default, because dot on Windows does not seem
+# to support this out of the box.
+#
+# Warning: Depending on the platform used, enabling this option may lead to
+# badly anti-aliased labels on the edges of a graph (i.e. they become hard to
+# read).
+# The default value is: NO.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+DOT_TRANSPARENT        = NO
 
 # Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
 # files in one run (i.e. multiple -o and -T options on the command line). This
@@ -2844,19 +2699,3 @@ GENERATE_LEGEND        = YES
 # The default value is: YES.
 
 DOT_CLEANUP            = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. If the MSCGEN_TOOL tag is left empty (the default), then doxygen will
-# use a built-in version of mscgen tool to produce the charts. Alternatively,
-# the MSCGEN_TOOL tag can also specify the name an external tool. For instance,
-# specifying prog as the value, doxygen will call the tool as prog -T
-# <outfile_format> -o <outputfile> <inputfile>. The external tool should support
-# output file formats "png", "eps", "svg", and "ismap".
-
-MSCGEN_TOOL            =
-
-# The MSCFILE_DIRS tag can be used to specify one or more directories that
-# contain msc files that are included in the documentation (see the \mscfile
-# command).
-
-MSCFILE_DIRS           =

--- a/include/ISSEvts.hh
+++ b/include/ISSEvts.hh
@@ -58,14 +58,14 @@ public:
 	TVector2	GetPhiXY();
 	TVector3	GetPosition();
 	
-	static char	FindPID( double z );
-	static char	FindNID( double phi );
-	static char	FindModule( double phi );
-	static char	FindRow( double z );
-	static char	FindModule( unsigned short detNo );
-	static char	FindRow( unsigned short detNo );
-	static char	FindAsicP( unsigned short detNo );
-	static char	FindAsicN( unsigned short detNo );
+	static int	FindPID( double z );
+	static int	FindNID( double phi );
+	static int	FindModule( double phi );
+	static int	FindRow( double z );
+	static int	FindModule( unsigned short detNo );
+	static int	FindRow( unsigned short detNo );
+	static int	FindAsicP( unsigned short detNo );
+	static int	FindAsicN( unsigned short detNo );
 	
 	
 private:

--- a/include/ISSEvts.hh
+++ b/include/ISSEvts.hh
@@ -83,7 +83,7 @@ private:
 	double			ntime;	///< n-side timestamp
 	
 	
-	ClassDef( ISSArrayEvt, 4 )
+	ClassDef( ISSArrayEvt, 5 )
 	
 };
 

--- a/include/ISSEvts.hh
+++ b/include/ISSEvts.hh
@@ -58,14 +58,14 @@ public:
 	TVector2	GetPhiXY();
 	TVector3	GetPosition();
 	
-	char	FindPID( double z );
-	char	FindNID( double phi );
-	char	FindModule( double phi );
-	char	FindRow( double z );
-	char	FindModule( unsigned short detNo );
-	char	FindRow( unsigned short detNo );
-	char	FindAsicP( unsigned short detNo );
-	char	FindAsicN( unsigned short detNo );
+	static char	FindPID( double z );
+	static char	FindNID( double phi );
+	static char	FindModule( double phi );
+	static char	FindRow( double z );
+	static char	FindModule( unsigned short detNo );
+	static char	FindRow( unsigned short detNo );
+	static char	FindAsicP( unsigned short detNo );
+	static char	FindAsicN( unsigned short detNo );
 	
 	
 private:

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -497,6 +497,23 @@ public:
 		laser = laserflag;
 	};
 	
+	// Getters
+	inline double GetThetaCM(){ return theta_cm; };
+	inline double GetThetaLab(){ return theta_lab; };
+	inline double GetDistanceMeasured(){ return z_meas; };
+	inline double GetDistance(){ return z; };
+	inline double GetPhi(){ return phi; };
+	inline double GetPhiMeasured(){ return phi_meas; };
+	inline double GetRadiusMeasured(){ return r_meas; };
+	inline double GetEnergyDetected(){ return Edet; };
+	inline double GetEx(){ return Ex; };
+	inline double GetQvalue(){ return Qvalue; };
+	inline double GetGammaEjectile(){ return gamma_ejectile; };
+	inline double GetBetaEjectile(){ return beta_ejectile; };
+	inline double GetEBISTime(){ return ebis_td; };
+	inline double GetT1Time(){ return t1_td; };
+	inline bool GetLaserStatus(){ return laser; };
+
 private:
 	
 	// Members of the class
@@ -527,6 +544,14 @@ public:
 		gamma = react->GetGamma();
 		beta = react->GetBeta();
 	};
+	
+	// Getters
+	inline double GetField(){ return Mfield; };
+	inline double GetEnergyTotalLab(){ return Etot_lab; };
+	inline double GetEnergyTotalCM(){ return Etot_cm; };
+	inline double GetGamma(){ return gamma; };
+	inline double GetBeta(){ return beta; };
+
 	
 private:
 	

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -480,8 +480,8 @@ public:
 	
 	// Set function
 	inline void SetRxEvent( std::shared_ptr<ISSReaction> react, double E, double ebistime, double t1time, bool laserflag ){
-		theta_cm = react->GetThetaLab();
-		theta_lab = react->GetThetaCM();
+		theta_cm = react->GetThetaCM();
+		theta_lab = react->GetThetaLab();
 		z = react->GetDistance();
 		z_meas = react->GetDistanceMeasured();
 		phi = react->GetPhi();
@@ -513,6 +513,12 @@ public:
 	inline double GetEBISTime(){ return ebis_td; };
 	inline double GetT1Time(){ return t1_td; };
 	inline bool GetLaserStatus(){ return laser; };
+	
+	// Getters for some derived data
+	inline char GetPID(){ return ISSArrayEvt::FindPID( z_meas ); };
+	inline char GetNID(){ return ISSArrayEvt::FindNID( phi_meas ); };
+	inline char GetRow(){ return ISSArrayEvt::FindRow( z_meas ); };
+	inline char GetModule(){ return ISSArrayEvt::FindModule( phi_meas ); };
 
 private:
 	

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -495,30 +495,43 @@ public:
 		ebis_td = ebistime;
 		t1_td = t1time;
 		laser = laserflag;
+		
+		// Hit information is derived, depends on array orientation
+		if( z_meas < 0 ) {
+			mod = ISSArrayEvt::FindModule( -1.0 * phi_meas );
+			nid = ISSArrayEvt::FindNID( -1.0 * phi_meas );
+			row = ISSArrayEvt::FindRow( -1.0 * ( z_meas - react->GetArrayDistance() ) );
+			pid = ISSArrayEvt::FindPID( -1.0 * ( z_meas - react->GetArrayDistance() ) );
+		}
+		else {
+			mod = ISSArrayEvt::FindModule( phi_meas );
+			nid = ISSArrayEvt::FindNID( phi_meas );
+			row = ISSArrayEvt::FindRow( z_meas - react->GetArrayDistance() );
+			pid = ISSArrayEvt::FindPID( z_meas - react->GetArrayDistance() );
+		}
+
 	};
 	
 	// Getters
-	inline double GetThetaCM(){ return theta_cm; };
-	inline double GetThetaLab(){ return theta_lab; };
-	inline double GetDistanceMeasured(){ return z_meas; };
-	inline double GetDistance(){ return z; };
-	inline double GetPhi(){ return phi; };
-	inline double GetPhiMeasured(){ return phi_meas; };
-	inline double GetRadiusMeasured(){ return r_meas; };
-	inline double GetEnergyDetected(){ return Edet; };
-	inline double GetEx(){ return Ex; };
-	inline double GetQvalue(){ return Qvalue; };
-	inline double GetGammaEjectile(){ return gamma_ejectile; };
-	inline double GetBetaEjectile(){ return beta_ejectile; };
-	inline double GetEBISTime(){ return ebis_td; };
-	inline double GetT1Time(){ return t1_td; };
-	inline bool GetLaserStatus(){ return laser; };
-	
-	// Getters for some derived data
-	inline char GetPID(){ return ISSArrayEvt::FindPID( z_meas ); };
-	inline char GetNID(){ return ISSArrayEvt::FindNID( phi_meas ); };
-	inline char GetRow(){ return ISSArrayEvt::FindRow( z_meas ); };
-	inline char GetModule(){ return ISSArrayEvt::FindModule( phi_meas ); };
+	inline double 	GetThetaCM(){ return theta_cm; };
+	inline double 	GetThetaLab(){ return theta_lab; };
+	inline double 	GetDistanceMeasured(){ return z_meas; };
+	inline double 	GetDistance(){ return z; };
+	inline double 	GetPhi(){ return phi; };
+	inline double 	GetPhiMeasured(){ return phi_meas; };
+	inline double 	GetRadiusMeasured(){ return r_meas; };
+	inline double 	GetEnergyDetected(){ return Edet; };
+	inline double 	GetEx(){ return Ex; };
+	inline double 	GetQvalue(){ return Qvalue; };
+	inline double 	GetGammaEjectile(){ return gamma_ejectile; };
+	inline double 	GetBetaEjectile(){ return beta_ejectile; };
+	inline double 	GetEBISTime(){ return ebis_td; };
+	inline double 	GetT1Time(){ return t1_td; };
+	inline int		GetPID(){ return pid; };
+	inline int		GetNID(){ return nid; };
+	inline int		GetRow(){ return row; };
+	inline int		GetModule(){ return mod; };
+	inline bool		GetLaserStatus(){ return laser; };
 
 private:
 	
@@ -528,9 +541,10 @@ private:
 	double Edet, Ex, Qvalue;
 	double gamma_ejectile, beta_ejectile;
 	double ebis_td, t1_td;
+	int mod, row, pid, nid;
 	bool laser;
 	
-	ClassDef( ISSRxEvent, 1 )
+	ClassDef( ISSRxEvent, 2 )
 	
 };
 
@@ -545,6 +559,7 @@ public:
 	// Set function
 	inline void SetRxInfo( std::shared_ptr<ISSReaction> react ){
 		Mfield = react->GetField();
+		ArrayDistance = react->GetArrayDistance();
 		Etot_lab = react->GetEnergyTotLab();
 		Etot_cm = react->GetEnergyTotCM();
 		gamma = react->GetGamma();
@@ -562,11 +577,11 @@ public:
 private:
 	
 	// Members of the class
-	double Mfield;
+	double Mfield, ArrayDistance;
 	double Etot_lab, Etot_cm;
 	double gamma, beta;
 	
-	ClassDef( ISSRxInfo, 1 )
+	ClassDef( ISSRxInfo, 2 )
 	
 };
 

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -1176,7 +1176,7 @@ double ISSReaction::SimulateDecay( TVector3 vec, double en, int detector ){
 	z_meas = vec.Z();					// measured z in mm
 	if( z0 < 0 ) {						// upstream
 		z_meas = z0 - z_meas;
-		phi_meas = -1.0 * vec.Phi();
+		phi_meas = TMath::TwoPi() - vec.Phi();
 	}
 	else {								// downstream
 		z_meas += z0;
@@ -1216,7 +1216,8 @@ double ISSReaction::SimulateDecay( TVector3 vec, double en, int detector ){
 	alpha  = TMath::ASin( alpha );
 	Ejectile.SetThetaLab( TMath::PiOver2() + alpha );
 	
-	// Phi
+	// Phi - TODO: this depends on direction of the field!
+	if( phi_meas < 0 ) phi_meas += TMath::TwoPi();
 	phi = phi_meas * z / z_meas + TMath::Pi();
 	if( phi > TMath::TwoPi() ) phi -= TMath::TwoPi();
 	
@@ -1334,7 +1335,7 @@ void ISSReaction::MakeReaction( TVector3 vec, double en ){
 	r_meas = vec.Perp();				// measured radius
 	if( z0 < 0 ) {						// upstream
 		z_meas = z0 - z_meas;
-		phi_meas = -1.0 * vec.Phi();
+		phi_meas = TMath::TwoPi() - vec.Phi();
 	}
 	else {								// downstream
 		z_meas += z0;
@@ -1471,7 +1472,8 @@ void ISSReaction::MakeReaction( TVector3 vec, double en ){
 		Recoil.SetEx( Ex );
 		Ejectile.SetEx( 0.0 );
 		
-		// Phi
+		// Phi - TODO: This depends on the direction of the field!
+		if( phi_meas < 0 ) phi_meas += TMath::TwoPi();
 		phi = phi_meas * z / z_meas + TMath::Pi();
 		if( phi > TMath::TwoPi() ) phi -= TMath::TwoPi();
 

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -1174,9 +1174,14 @@ double ISSReaction::SimulateDecay( TVector3 vec, double en, int detector ){
 	// Set the input parameters, might use them in another function
 	Ejectile.SetEnergyLab(en);			// ejectile energy in keV
 	z_meas = vec.Z();					// measured z in mm
-	if( z0 < 0 ) z_meas = z0 - z_meas;	// upstream
-	else z_meas += z0;					// downstream
-	phi_meas = vec.Phi();
+	if( z0 < 0 ) {						// upstream
+		z_meas = z0 - z_meas;
+		phi_meas = -1.0 * vec.Phi();
+	}
+	else {								// downstream
+		z_meas += z0;
+		phi_meas = vec.Phi();
+	}
 	
 	//------------------------//
 	// Kinematics calculation //
@@ -1327,9 +1332,14 @@ void ISSReaction::MakeReaction( TVector3 vec, double en ){
 	//Ejectile.SetEnergyLab(en);		// ejectile energy in keV
 	z_meas = vec.Z();					// measured z in mm
 	r_meas = vec.Perp();				// measured radius
-	if( z0 < 0 ) z_meas = z0 - z_meas;	// upstream
-	else z_meas += z0;					// downstream
-	phi_meas = vec.Phi();
+	if( z0 < 0 ) {						// upstream
+		z_meas = z0 - z_meas;
+		phi_meas = -1.0 * vec.Phi();
+	}
+	else {								// downstream
+		z_meas += z0;
+		phi_meas = vec.Phi();
+	}
 
 	// Pulse height conversion to proton energy using RDP
 	en = GetPulseHeightCorrection( en, true );

--- a/utils/elum_energy_calculator.cc
+++ b/utils/elum_energy_calculator.cc
@@ -3,7 +3,7 @@
 
 // To run this, do the following:
 // root -l
-// root [0] gSystem->Load("libiss_sort.so")
+// root [0] gSystem->Load("libiss_sort")
 // root [1] .L utils/elum_energy_calculator.cc
 // root [2] elum_energy_calculator
 

--- a/utils/plot_from_rxtree.cc
+++ b/utils/plot_from_rxtree.cc
@@ -37,7 +37,7 @@ void plot_from_rxtree( std::string rootfile = "myhists.root",
 	t->SetBranchAddress( "RxInfo", &myrxinfo );
 
 	// Make a histogram or two
-	TH2F *zphimap = new TH2F( "zphimap", "z-phi hit map", 1000, -1000, 1000, 440, -40, 400 );
+	TH2F *zphimap = new TH2F( "zphimap", "z-phi hit map", 1000, -1000, 1000, 560, -100, 460 );
 	TH2F *pmodmap = new TH2F( "pmodmap", "p vs module hit map", 512, -0.5, 511.5, 3, -0.5, 2.5 );
 	TH2F *pnmap = new TH2F( "pnmap", "p vs n hit map", 512, -0.5, 511.5, 264, -0.5, 263.5 );
 

--- a/utils/plot_from_rxtree.cc
+++ b/utils/plot_from_rxtree.cc
@@ -1,0 +1,63 @@
+// An example script to show how to plot data from the rxtree
+// including looking up the strip and module IDs for the array
+
+// To run this, do the following:
+// root -l
+// root [0] gSystem->Load("libiss_sort.so")
+// root [1] .L utils/elum_energy_calculator.cc
+// root [2] elum_energy_calculator
+
+// Maybe you need to include the headers, depending on the ROOT
+// version. New version require you only to load a library.
+//#include “Settings.hh”
+//#include “ISSEvts.hh”
+//#include “Reaction.hh”
+
+// Create a settings reaction and events instance
+std::shared_ptr<ISSSettings> myset;
+std::shared_ptr<ISSArrayEvt> myevt;
+std::shared_ptr<ISSReaction> myreact;
+std::shared_ptr<ISSRxEvent>  myrxevt;
+
+void plot_from_rxtree( std::string reaction_file = "dummy" ) {
+	
+	// Open file and get tree
+	TFile *f = new TFile( “myhists.root” );
+	TTree *t = (TTree*)f->Get(“rxtree”);
+	
+	// Make a reaction instance, etc
+	myset = std::make_shared<ISSSettings>( "dummy" );
+	myreact = std::make_shared<ISSReaction>( reaction_file, myset, false );
+	myevt = std::make_shared<ISSArrayEvt>();
+	
+	// Set branches
+	myrxevt = std::make_shared<ISSRxEvent>();
+	myrxinf = std::make_shared<ISSRxInfo>();
+	t->SetBranchAddress( "RxEvent", &myrxevt );
+	t->SetBranchAddress( "RxInfo", &myrxinfo );
+
+	// Make a histogram or two
+	TH2F *zphimap = new TH2F( "zphimap", "z-phi hit map", 1000, -1000, 1000, 360, 0, 360 );
+	TH2F *pmodmap = new TH2F( "pmodmap", "p vs module hit map", 512, -0.5, 511.5, 3, -0.5, 2.5 );
+
+	// Loop over events
+	for( unsigned int i = 0; i < t->GetEntries(); i++ ){
+		
+		// Get entry
+		t->GetEntry(i);
+		
+		// Calculate module number
+		int mymod = FindModule( myrxevt->GetPhiMeasured() );
+		int mypid = FindPID( myrxevt->GetDistanceMeasured() );
+		int mynid = FindNID( myrxevt->GetPhiMeasured() );
+		int myrow = FindRow( myrxevt->GetDistanceMeasured() );
+
+		// Plot hit maps
+		zphimap->Fill( myrxevt->GetDistance(), myrxevt->GetPhi() ); // reaction z-phi, not measured z-phi
+		pmodmap->Fill( myrow*128 + mypid, mymod );
+		
+	}
+	
+	return;
+	
+}

--- a/utils/plot_from_rxtree.cc
+++ b/utils/plot_from_rxtree.cc
@@ -3,7 +3,7 @@
 
 // To run this, do the following:
 // root -l
-// root [0] gSystem->Load("libiss_sort.so")
+// root [0] gSystem->Load("libiss_sort")
 // root [1] .L utils/elum_energy_calculator.cc
 // root [2] elum_energy_calculator
 
@@ -15,30 +15,29 @@
 
 // Create a settings reaction and events instance
 std::shared_ptr<ISSSettings> myset;
-std::shared_ptr<ISSArrayEvt> myevt;
 std::shared_ptr<ISSReaction> myreact;
-std::shared_ptr<ISSRxEvent>  myrxevt;
 
-void plot_from_rxtree( std::string reaction_file = "dummy" ) {
+void plot_from_rxtree( std::string rootfile = "myhists.root",
+					   std::string reaction_file = "dummy" ) {
 	
 	// Open file and get tree
-	TFile *f = new TFile( “myhists.root” );
-	TTree *t = (TTree*)f->Get(“rxtree”);
+	TFile *f = new TFile( rootfile.data() );
+	TTree *t = (TTree*)f->Get("rxtree");
 	
 	// Make a reaction instance, etc
 	myset = std::make_shared<ISSSettings>( "dummy" );
 	myreact = std::make_shared<ISSReaction>( reaction_file, myset, false );
-	myevt = std::make_shared<ISSArrayEvt>();
 	
 	// Set branches
-	myrxevt = std::make_shared<ISSRxEvent>();
-	myrxinf = std::make_shared<ISSRxInfo>();
+	ISSRxEvent *myrxevt = new ISSRxEvent();
+	ISSRxInfo *myrxinfo = new ISSRxInfo();
 	t->SetBranchAddress( "RxEvent", &myrxevt );
 	t->SetBranchAddress( "RxInfo", &myrxinfo );
 
 	// Make a histogram or two
-	TH2F *zphimap = new TH2F( "zphimap", "z-phi hit map", 1000, -1000, 1000, 360, 0, 360 );
+	TH2F *zphimap = new TH2F( "zphimap", "z-phi hit map", 1000, -1000, 1000, 360, -180, 180 );
 	TH2F *pmodmap = new TH2F( "pmodmap", "p vs module hit map", 512, -0.5, 511.5, 3, -0.5, 2.5 );
+	TH2F *pnmap = new TH2F( "pnmap", "p vs n hit map", 512, -0.5, 511.5, 264, -0.5, 263.5 );
 
 	// Loop over events
 	for( unsigned int i = 0; i < t->GetEntries(); i++ ){
@@ -47,15 +46,18 @@ void plot_from_rxtree( std::string reaction_file = "dummy" ) {
 		t->GetEntry(i);
 		
 		// Calculate module number
-		int mymod = FindModule( myrxevt->GetPhiMeasured() );
-		int mypid = FindPID( myrxevt->GetDistanceMeasured() );
-		int mynid = FindNID( myrxevt->GetPhiMeasured() );
-		int myrow = FindRow( myrxevt->GetDistanceMeasured() );
+		double z = myrxevt->GetDistance();
+		double phi = myrxevt->GetPhi();
+		int mymod = myrxevt->GetModule();
+		int mypid = myrxevt->GetPID();
+		int mynid = myrxevt->GetNID();
+		int myrow = myrxevt->GetRow();
 
 		// Plot hit maps
-		zphimap->Fill( myrxevt->GetDistance(), myrxevt->GetPhi() ); // reaction z-phi, not measured z-phi
+		zphimap->Fill( z, phi*TMath::RadToDeg() ); // reaction z-phi, not measured z-phi
 		pmodmap->Fill( myrow*128 + mypid, mymod );
-		
+		pnmap->Fill( myrow*128 + mypid, mymod*88 + myrow*22 + mynid );
+
 	}
 	
 	return;

--- a/utils/plot_from_rxtree.cc
+++ b/utils/plot_from_rxtree.cc
@@ -13,6 +13,8 @@
 //#include “ISSEvts.hh”
 //#include “Reaction.hh”
 
+R__LOAD_LIBRARY(libiss_sort.so)
+
 // Create a settings reaction and events instance
 std::shared_ptr<ISSSettings> myset;
 std::shared_ptr<ISSReaction> myreact;
@@ -35,7 +37,7 @@ void plot_from_rxtree( std::string rootfile = "myhists.root",
 	t->SetBranchAddress( "RxInfo", &myrxinfo );
 
 	// Make a histogram or two
-	TH2F *zphimap = new TH2F( "zphimap", "z-phi hit map", 1000, -1000, 1000, 360, -180, 180 );
+	TH2F *zphimap = new TH2F( "zphimap", "z-phi hit map", 1000, -1000, 1000, 440, -40, 400 );
 	TH2F *pmodmap = new TH2F( "pmodmap", "p vs module hit map", 512, -0.5, 511.5, 3, -0.5, 2.5 );
 	TH2F *pnmap = new TH2F( "pnmap", "p vs n hit map", 512, -0.5, 511.5, 264, -0.5, 263.5 );
 
@@ -56,7 +58,7 @@ void plot_from_rxtree( std::string rootfile = "myhists.root",
 		// Plot hit maps
 		zphimap->Fill( z, phi*TMath::RadToDeg() ); // reaction z-phi, not measured z-phi
 		pmodmap->Fill( myrow*128 + mypid, mymod );
-		pnmap->Fill( myrow*128 + mypid, mymod*88 + myrow*22 + mynid );
+		pnmap->Fill( myrow*128 + mypid, mymod*88 + mynid );
 
 	}
 	

--- a/utils/z_to_angle_simulator.cc
+++ b/utils/z_to_angle_simulator.cc
@@ -4,7 +4,7 @@
 
 // To run this, do the following:
 // root -l
-// root [0] gSystem->Load("libiss_sort.so")
+// root [0] gSystem->Load("libiss_sort")
 // root [1] .L utils/z_to_angle_simulator.cc++
 // root [2] z_to_angle_simulator( "reaction.dat" )
 // root [3] get_theta_cm( z_det, E_x )  --> in radians


### PR DESCRIPTION
Fix some bugs in the phi angle calculations and update the reaction tree to include module ID, row number, p-side ID and n-side ID for the array events. Still not got recoil events in there (because nobody has asked for them yet).