### PR TITLE
Overflow fix

### DIFF
--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -185,7 +185,7 @@ void ISSConverter::MakeHists() {
 					
 				hasic[i][j] = new TH2F( hname.data(), htitle.data(),
 							set->GetNumberOfArrayChannels(), -0.5, set->GetNumberOfArrayChannels()-0.5,
-							4096, -0.5, 4095.5 );
+							4196, -0.5, 4195.5 );
 				hasic[i][j]->SetDirectory(
 						output_file->GetDirectory( dirname.data() ) );
 					
@@ -260,7 +260,7 @@ void ISSConverter::MakeHists() {
 			else {
 				
 				hcaen_qlong[i][j] = new TH1F( hname.data(), htitle.data(),
-											 65536, -0.5, 65535.5 );
+											 66536, -0.5, 66535.5 );
 				
 				hcaen_qlong[i][j]->SetDirectory(
 												output_file->GetDirectory( dirname.data() ) );
@@ -283,7 +283,7 @@ void ISSConverter::MakeHists() {
 			else {
 				
 				hcaen_qshort[i][j] = new TH1F( hname.data(), htitle.data(),
-											  32768, -0.5, 32767.5 );
+											  33768, -0.5, 33767.5 );
 				
 				hcaen_qshort[i][j]->SetDirectory(
 												 output_file->GetDirectory( dirname.data() ) );
@@ -306,7 +306,7 @@ void ISSConverter::MakeHists() {
 			else {
 				
 				hcaen_qdiff[i][j] = new TH1F( hname.data(), htitle.data(),
-											 65536, -0.5, 65535.5 );
+											 66536, -0.5, 66535.5 );
 				
 				hcaen_qdiff[i][j]->SetDirectory(
 												output_file->GetDirectory( dirname.data() ) );
@@ -382,7 +382,7 @@ void ISSConverter::MakeHists() {
 			else {
 				
 				hmesy_qlong[i][j] = new TH1F( hname.data(), htitle.data(),
-											 65536, -0.5, 65535.5 );
+											 66536, -0.5, 66535.5 );
 				
 				hmesy_qlong[i][j]->SetDirectory(
 												output_file->GetDirectory( dirname.data() ) );
@@ -405,7 +405,7 @@ void ISSConverter::MakeHists() {
 			else {
 				
 				hmesy_qshort[i][j] = new TH1F( hname.data(), htitle.data(),
-											  32768, -0.5, 32767.5 );
+											  33768, -0.5, 33767.5 );
 				
 				hmesy_qshort[i][j]->SetDirectory(
 												output_file->GetDirectory( dirname.data() ) );
@@ -428,7 +428,7 @@ void ISSConverter::MakeHists() {
 			else {
 				
 				hmesy_qdiff[i][j] = new TH1F( hname.data(), htitle.data(),
-											 65536, -0.5, 65535.5 );
+											 66536, -0.5, 66535.5 );
 				
 				hmesy_qdiff[i][j]->SetDirectory(
 												output_file->GetDirectory( dirname.data() ) );

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -1211,8 +1211,7 @@ void ISSConverter::ProcessCAENData(){
 		
 		// Fill histograms
 		hcaen_qlong[my_mod_id][my_ch_id]->Fill( my_adc_data );
-		if( my_adc_data == 0xFFFF ) caen_data->SetQlong( 0 );
-		else caen_data->SetQlong( my_adc_data );
+		caen_data->SetQlong( my_adc_data );
 		flag_caen_data0 = true;
 		
 	}
@@ -1222,8 +1221,7 @@ void ISSConverter::ProcessCAENData(){
 		
 		my_adc_data = my_adc_data & 0x7FFF; // 15 bits from 0
 		hcaen_qshort[my_mod_id][my_ch_id]->Fill( my_adc_data );
-		if( my_adc_data == 0x7FFF ) caen_data->SetQshort( 0 );
-		else caen_data->SetQshort( my_adc_data );
+		caen_data->SetQshort( my_adc_data );
 		flag_caen_data1 = true;
 		
 	}
@@ -1504,8 +1502,7 @@ void ISSConverter::ProcessMesytecData(){
 		
 		// Fill histograms
 		hmesy_qlong[my_mod_id][my_ch_id]->Fill( my_adc_data );
-		if( my_adc_data == 0xFFFF ) mesy_data->SetQlong( 0 );
-		else mesy_data->SetQlong( my_adc_data );
+		mesy_data->SetQlong( my_adc_data );
 		flag_mesy_data0 = true;
 		
 	}
@@ -1516,8 +1513,7 @@ void ISSConverter::ProcessMesytecData(){
 		// Fill histograms
 		my_adc_data = my_adc_data & 0x7FFF; // 15 bits from 0
 		hmesy_qshort[my_mod_id][my_ch_id]->Fill( my_adc_data );
-		if( my_adc_data == 0x7FFF ) mesy_data->SetQshort( 0 );
-		else mesy_data->SetQshort( my_adc_data );
+		mesy_data->SetQshort( my_adc_data );
 		flag_mesy_data1 = true;
 		
 	}


### PR DESCRIPTION
Fixed an issue where the max value of Qlong and Qshort was set to zero, causing overflow to not be visible.

Second commit is to extend some histograms so that the overflow bin is more visible (see attached figure below).


![overflow_update](https://github.com/user-attachments/assets/0f68fffc-bc52-4b18-aa3a-fd401c6a8d14)
