### PR TITLE
LUME histograms

### DIFF
--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -389,6 +389,7 @@ private:
 	TH1F *lume, *lume_ebis, *lume_ebis_on, *lume_ebis_off;
     TH2F *lume_E_vs_x, *lume_vs_T1, *lume_E_vs_x_ebis;
     TH2F *lume_E_vs_x_ebis_on, *lume_E_vs_x_ebis_off;
+    TH2F *lume_E_vs_x_wide;
 
 };
 

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -117,6 +117,11 @@ public:
 			z->GetTime() - read_evts->GetEBIS() < react->GetEBISOnTime() ) return true;
 		else return false;
 	};
+  	inline bool	OnBeam( std::shared_ptr<ISSLumeEvt> l ){
+		if( l->GetTime() - read_evts->GetEBIS() >= 0 &&
+			l->GetTime() - read_evts->GetEBIS() < react->GetEBISOnTime() ) return true;
+		else return false;
+	};
 	inline bool	OffBeam( std::shared_ptr<ISSRecoilEvt> r ){
 		if( r->GetTime() - read_evts->GetEBIS() >= react->GetEBISOnTime() &&
 			r->GetTime() - read_evts->GetEBIS() < react->GetEBISOffTime() ) return true;
@@ -183,7 +188,8 @@ private:
 	std::shared_ptr<ISSRecoilEvt> recoil_evt;
 	std::shared_ptr<ISSElumEvt> elum_evt;
 	std::shared_ptr<ISSZeroDegreeEvt> zd_evt;
-	
+    std::shared_ptr<ISSLumeEvt> lume_evt;
+
 	/// Output file and tree
 	TFile *output_file;
 	TTree *output_tree;
@@ -211,6 +217,7 @@ private:
 	TProfile *recoil_array_tw_hit0_prof, *recoil_array_tw_hit1_prof;
 	TH1F *ebis_td_recoil, *ebis_td_array, *ebis_td_elum;
 	TH1F *t1_td_recoil, *sc_td_recoil;
+    TH1F *ebis_td_lume;
 
 	// Recoils
 	std::vector<TH2F*> recoil_EdE;
@@ -369,7 +376,20 @@ private:
 	TH1F *elum_recoil, *elum_recoilT;
 	TH1F *elum_recoil_random, *elum_recoilT_random;
 	TH2F *elum_vs_T1;
-	
+
+    // LUME
+	std::vector<TH1F*> lume_det;
+	std::vector<TH1F*> lume_ebis_det;
+	std::vector<TH1F*> lume_ebis_on_det;
+	std::vector<TH1F*> lume_ebis_off_det;
+	std::vector<TH2F*> lume_E_vs_x_det;
+	std::vector<TH2F*> lume_E_vs_x_ebis_det;
+	std::vector<TH2F*> lume_E_vs_x_ebis_on_det;
+	std::vector<TH2F*> lume_E_vs_x_ebis_off_det;
+	TH1F *lume, *lume_ebis, *lume_ebis_on, *lume_ebis_off;
+    TH2F *lume_E_vs_x, *lume_vs_T1, *lume_E_vs_x_ebis;
+    TH2F *lume_E_vs_x_ebis_on, *lume_E_vs_x_ebis_off;
+
 };
 
 #endif

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -2626,8 +2626,8 @@ void ISSEventBuilder::LumeFinder() {
 				break;
 			}
 		}
-		ne_energy = has_ln ? ne_energy : TMath::QuietNaN();
-		fe_energy =  has_lf ? fe_energy : TMath::QuietNaN();
+		ne_energy = has_ln ? ne_energy : 0;
+		fe_energy =  has_lf ? fe_energy : 0;
 
 		lume_evt->SetEvent(be_energy, be_id, be_timestamp, ne_energy, fe_energy);
 

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -2626,8 +2626,10 @@ void ISSEventBuilder::LumeFinder() {
 				break;
 			}
 		}
+		ne_energy = has_ln ? ne_energy : TMath::QuietNaN();
+		fe_energy =  has_lf ? fe_energy : TMath::QuietNaN();
 
-		lume_evt->SetEvent(be_energy, be_id, be_timestamp, has_ln ? ne_energy : TMath::QuietNaN(), has_lf ? fe_energy : TMath::QuietNaN() );
+		lume_evt->SetEvent(be_energy, be_id, be_timestamp, ne_energy, fe_energy);
 
 		if (has_ln && has_lf)
 		  lume_E_vs_x[be_id]->Fill(( fe_energy - ne_energy ) / ( ne_energy + fe_energy ), be_energy);

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -3031,11 +3031,11 @@ void ISSEventBuilder::MakeHists(){
 	for( unsigned int i = 0; i < set->GetNumberOfLUMEDetectors(); ++i ) {
 
 		hname = "lume_E_" + std::to_string(i);
-		htitle = "LUME energy spectrum;Energy [ch];Counts";
+		htitle = "LUME energy spectrum;Energy [keV];Counts";
 		lume_E[i] = new TH1F( hname.data(), htitle.data(), 1000, -200, 80000);
 
 		hname = "lume_E_vs_x_" + std::to_string(i);
-		htitle = "LUME energy vs position spectrum;Position;Energy [ch]";
+		htitle = "LUME energy vs position spectrum;Position;Energy [keV]";
 		lume_E_vs_x[i] = new TH2F( hname.data(), htitle.data(), 1000, -1.01, 1.01, 1000, -200, 80000 );
 
 	}

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -2630,7 +2630,7 @@ void ISSEventBuilder::LumeFinder() {
 		lume_evt->SetEvent(be_energy, be_id, be_timestamp, has_ln ? ne_energy : TMath::QuietNaN(), has_lf ? fe_energy : TMath::QuietNaN() );
 
 		if (has_ln && has_lf)
-		  lume_E_vs_x[be_id]->Fill(( ne_energy - fe_energy ) / ( ne_energy + fe_energy ), be_energy);
+		  lume_E_vs_x[be_id]->Fill(( fe_energy - ne_energy ) / ( ne_energy + fe_energy ), be_energy);
 
 		write_evts->AddEvt( lume_evt );
 		lume_ctr++;

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -2631,8 +2631,11 @@ void ISSEventBuilder::LumeFinder() {
 
 		lume_evt->SetEvent(be_energy, be_id, be_timestamp, ne_energy, fe_energy);
 
-		if (has_ln || has_lf)
-		  lume_E_vs_x[be_id]->Fill(( fe_energy - ne_energy ) / ( ne_energy + fe_energy ), be_energy);
+		if (has_ln || has_lf){
+		  double x = ( fe_energy - ne_energy ) / ( ne_energy + fe_energy );
+		  lume_evt->SetX(x);
+		  lume_E_vs_x[be_id]->Fill(x, be_energy);
+		}
 
 		write_evts->AddEvt( lume_evt );
 		lume_ctr++;

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -3036,12 +3036,12 @@ void ISSEventBuilder::MakeHists(){
 	for( unsigned int i = 0; i < set->GetNumberOfLUMEDetectors(); ++i ) {
 
 		hname = "lume_E_" + std::to_string(i);
-		htitle = "LUME energy spectrum;Energy [keV];Counts";
-		lume_E[i] = new TH1F( hname.data(), htitle.data(), 1000, -200, 80000);
+		htitle = "LUME energy spectrum;Energy [keV];Counts per 2 keV";
+		lume_E[i] = new TH1F( hname.data(), htitle.data(), 4100, -200, 8000);
 
 		hname = "lume_E_vs_x_" + std::to_string(i);
 		htitle = "LUME energy vs position spectrum;Position;Energy [keV]";
-		lume_E_vs_x[i] = new TH2F( hname.data(), htitle.data(), 1000, -1.01, 1.01, 1000, -200, 80000 );
+		lume_E_vs_x[i] = new TH2F( hname.data(), htitle.data(), 400, -2., 2., 4100, -200, 8000 );
 
 	}
 

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -2631,7 +2631,7 @@ void ISSEventBuilder::LumeFinder() {
 
 		lume_evt->SetEvent(be_energy, be_id, be_timestamp, ne_energy, fe_energy);
 
-		if (has_ln && has_lf)
+		if (has_ln || has_lf)
 		  lume_E_vs_x[be_id]->Fill(( fe_energy - ne_energy ) / ( ne_energy + fe_energy ), be_energy);
 
 		write_evts->AddEvt( lume_evt );

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1243,6 +1243,7 @@ void ISSHistogrammer::MakeHists() {
 	lume_E_vs_x_ebis = new TH2F( "lume_E_vs_x_ebis", "LUME energy versus position gated by EBIS and off beam subtracted;Position;Energy (keV)", 400, -2, 2, 1640, -200, 8000 );
 	lume_E_vs_x_ebis_on = new TH2F( "lume_E_vs_x_ebis_on", "LUME energy versus position gated on EBIS;Position;Energy (keV)", 400, -2, 2, 1640, -200, 8000 );
 	lume_E_vs_x_ebis_off = new TH2F( "lume_E_vs_x_ebis_off", "LUME energy versus positiongated off EBIS ;Position;Energy (keV)", 400, -2, 2, 1640, -200, 8000 );
+	lume_E_vs_x_wide = new TH2F( "lume_E_vs_x_wide", "LUME energy versus position;Position;Energy (keV)", 400, -2, 2, 8000, -200, 160000 );
 
 	lume_det.resize( set->GetNumberOfLUMEDetectors() );
 	lume_ebis_det.resize( set->GetNumberOfLUMEDetectors() );
@@ -1769,6 +1770,7 @@ void ISSHistogrammer::ResetHists() {
 
 	lume->Reset("ICESM");
 	lume_E_vs_x->Reset("ICESM");
+	lume_E_vs_x_wide->Reset("ICESM");
 	lume_ebis->Reset("ICESM");
 	lume_ebis_on->Reset("ICESM");
 	lume_ebis_off->Reset("ICESM");
@@ -2378,6 +2380,7 @@ unsigned long ISSHistogrammer::FillHists() {
 
 			// E versus x
 			lume_E_vs_x->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
+			lume_E_vs_x_wide->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
 			lume_E_vs_x_det[det_id]->Fill( lume_evt->GetX(),lume_evt->GetBE(),1 );
 
 			// Check for events in the EBIS on-beam window

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1150,6 +1150,7 @@ void ISSHistogrammer::MakeHists() {
 	ebis_td_recoil = new TH1F( "ebis_td_recoil", "Recoil time with respect to EBIS;#Deltat;Counts per 20 #mus", 5.5e3, -0.1e8, 1e8  );
 	ebis_td_array = new TH1F( "ebis_td_array", "Array time with respect to EBIS;#Deltat;Counts per 20 #mus", 5.5e3, -0.1e8, 1e8  );
 	ebis_td_elum = new TH1F( "ebis_td_elum", "ELUM time with respect to EBIS;#Deltat;Counts per 20 #mus", 5.5e3, -0.1e8, 1e8  );
+	ebis_td_lume = new TH1F( "ebis_td_lume", "LUME time with respect to EBIS;#Deltat;Counts per 20 #mus", 5.5e3, -0.1e8, 1e8  );
 	
 	// Supercycle and proton pulses
 	t1_td_recoil = new TH1F( "t1_td_recoil", "Recoil time difference with respect to the T1;#Deltat;Counts per 20 #mus", 5.5e3, -0.1e11, 1e11 );
@@ -1227,7 +1228,78 @@ void ISSHistogrammer::MakeHists() {
 		elum_recoilT_random_sec[j] = new TH1F( hname.data(), htitle.data(), 10000, 0, 50000 );
 
 	} // ELUM
-	
+
+	// For LUME detectors
+	dirname = "LumeDetector";
+	output_file->mkdir( dirname.data() );
+	output_file->cd( dirname.data() );
+
+	lume = new TH1F( "lume", "LUME singles;Energy (keV);Counts per 5 keV", 10100, -200, 50000 );
+	lume_ebis = new TH1F( "lume_ebis", "LUME gated by EBIS and off beam subtracted;Energy (keV);Counts per 5 keV", 10100, -200, 50000 );
+	lume_ebis_on = new TH1F( "lume_ebis_on", "LUME gated on EBIS;Energy (keV);Counts per 5 keV", 10100, -200, 50000 );
+	lume_ebis_off = new TH1F( "lume_ebis_off", "LUME gated off EBIS;Energy (keV);Counts per 5 keV", 10100, -200, 50000 );
+	lume_vs_T1 = new TH2F( "lume_vs_T1", "LUME energy versus T1 time (gated on EBIS);Energy (keV);Counts per 5 keV", 5000, 0, 50e9, 10100, -200, 50000 );
+	lume_E_vs_x = new TH2F( "lume_E_vs_x", "LUME energy versus position;Position;Energy (keV)", 400, -2, 2, 1640, -200, 8000 );
+	lume_E_vs_x_ebis = new TH2F( "lume_E_vs_x_ebis", "LUME energy versus position gated by EBIS and off beam subtracted;Position;Energy (keV)", 400, -2, 2, 1640, -200, 8000 );
+	lume_E_vs_x_ebis_on = new TH2F( "lume_E_vs_x_ebis_on", "LUME energy versus position gated on EBIS;Position;Energy (keV)", 400, -2, 2, 1640, -200, 8000 );
+	lume_E_vs_x_ebis_off = new TH2F( "lume_E_vs_x_ebis_off", "LUME energy versus positiongated off EBIS ;Position;Energy (keV)", 400, -2, 2, 1640, -200, 8000 );
+
+	lume_det.resize( set->GetNumberOfLUMEDetectors() );
+	lume_ebis_det.resize( set->GetNumberOfLUMEDetectors() );
+	lume_ebis_on_det.resize( set->GetNumberOfLUMEDetectors() );
+	lume_ebis_off_det.resize( set->GetNumberOfLUMEDetectors() );
+	lume_E_vs_x_det.resize( set->GetNumberOfLUMEDetectors() );
+	lume_E_vs_x_ebis_det.resize( set->GetNumberOfLUMEDetectors() );
+	lume_E_vs_x_ebis_on_det.resize( set->GetNumberOfLUMEDetectors() );
+	lume_E_vs_x_ebis_off_det.resize( set->GetNumberOfLUMEDetectors() );
+
+	// Loop over number of LUME detectors
+	for( unsigned int i = 0; i < set->GetNumberOfLUMEDetectors(); ++i ) {
+	  dirname = "LumeDetector/detector_" + std::to_string(i);
+	  output_file->mkdir( dirname.data() );
+	  output_file->cd( dirname.data() );
+
+	  hname = "lume_det_" + std::to_string(i);
+	  htitle = "LUME energy spectrum for detector " + std::to_string(i);
+	  htitle += ";Energy [keV];Counts per 5 keV";
+	  lume_det[i] = new TH1F( hname.data(), htitle.data(), 10100, -200, 50000);
+
+	  hname = "lume_ebis_det_" + std::to_string(i);
+	  htitle = "LUME events for  detector " + std::to_string(i);
+	  htitle += " gated by EBIS and off beam subtracted;Energy (keV);Counts per 5 keV";
+	  lume_ebis_det[i] = new TH1F( hname.data(), htitle.data(), 10100, -200, 50000 );
+
+	  hname = "lume_ebis_on_det_" + std::to_string(i);
+	  htitle = "LUME events for detector " + std::to_string(i);
+	  htitle += " gated on EBIS ;Energy (keV);Counts per 5 keV";
+	  lume_ebis_on_det[i] = new TH1F( hname.data(), htitle.data(), 10100, -200, 50000 );
+
+	  hname = "lume_ebis_off_det_" + std::to_string(i);
+	  htitle = "LUME events for detector " + std::to_string(i);
+	  htitle += " gated off EBIS ;Energy (keV);Counts per 5 keV";
+	  lume_ebis_off_det[i] = new TH1F( hname.data(), htitle.data(), 10100, -200, 50000 );
+
+	  hname = "lume_E_vs_x_det_" + std::to_string(i);
+	  htitle = "LUME energy vs position spectrum for detecor " + std::to_string(i);
+	  htitle += ";Position;Energy [keV]";
+	  lume_E_vs_x_det[i] = new TH2F( hname.data(), htitle.data(), 400, -2., 2., 1640, -200, 8000 );
+
+	  hname = "lume_E_vs_x_ebis_det_" + std::to_string(i);
+	  htitle = "LUME energy vs position spectrum for detector " + std::to_string(i);
+	  htitle += " gated by EBIS and off beam subtracted;Position;Energy [keV]";
+	  lume_E_vs_x_ebis_det[i] = new TH2F( hname.data(), htitle.data(), 400, -2., 2., 1640, -200, 8000 );
+
+	  hname = "lume_E_vs_x_ebis_on_det_" + std::to_string(i);
+	  htitle = "LUME energy vs position spectrum for detecor " + std::to_string(i);
+	  htitle += " gated on EBIS;Position;Energy [keV]";
+	  lume_E_vs_x_ebis_on_det[i] = new TH2F( hname.data(), htitle.data(), 400, -2., 2., 1640, -200, 8000 );
+
+	  hname = "lume_E_vs_x_ebis_off_det_" + std::to_string(i);
+	  htitle = "LUME energy vs position spectrum for detecor " + std::to_string(i);
+	  htitle += " gated off EBIS;Position;Energy [keV]";
+	  lume_E_vs_x_ebis_off_det[i] = new TH2F( hname.data(), htitle.data(), 400, -2., 2., 1640, -200, 8000 );
+	} // LUME
+
 	output_file->cd();
 	
 }

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -2356,7 +2356,55 @@ unsigned long ISSHistogrammer::FillHists() {
 			recoil_E_eloss[recoil_evt->GetSector()]->Fill( recoil_evt->GetEnergyRest( set->GetRecoilEnergyRestStart(), set->GetRecoilEnergyRestStop() ) );
 
 		} // recoils
-		
+
+		// Loop over LUME events
+		for( unsigned int j = 0; j < read_evts->GetLumeMultiplicity(); ++j ){
+			// Get LUME event
+			lume_evt = read_evts->GetLumeEvt(j);
+
+			int det_id = lume_evt->GetID();
+			if (det_id >= set->GetNumberOfLUMEDetectors()){
+			  std::cerr << "Bad LUME detector ID " << det_id << ". Only " << set->GetNumberOfLUMEDetectors()
+						<< " detectors are set. Ignoring this event for histogramming." << std::endl;
+			  continue;
+			}
+
+			// EBIS time
+			ebis_td_lume->Fill( lume_evt->GetTime() - read_evts->GetEBIS() );
+
+			// Singles
+			lume->Fill( lume_evt->GetBE() );
+			lume_det[det_id]->Fill( lume_evt->GetBE() );
+
+			// E versus x
+			lume_E_vs_x->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
+			lume_E_vs_x_det[det_id]->Fill( lume_evt->GetX(),lume_evt->GetBE(),1 );
+
+			// Check for events in the EBIS on-beam window
+			if( OnBeam( lume_evt ) ){
+
+			  lume_vs_T1->Fill( lume_evt->GetTime() - read_evts->GetT1(), lume_evt->GetBE() );
+			  lume_ebis_on->Fill( lume_evt->GetBE() );
+			  lume_E_vs_x_ebis->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
+			  lume_E_vs_x_ebis_on->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
+
+			  lume_ebis_on_det[det_id]->Fill( lume_evt->GetBE() );
+			  lume_E_vs_x_ebis_det[det_id]->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
+			  lume_E_vs_x_ebis_on_det[det_id]->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
+			}
+
+			else {
+
+			  lume_ebis_off->Fill( lume_evt->GetBE() );
+			  lume_ebis_off_det[det_id]->Fill( lume_evt->GetBE() );
+
+			  lume_E_vs_x_ebis->Fill( lume_evt->GetX(),lume_evt->GetBE(),-1.* react->GetEBISFillRatio() );
+			  lume_E_vs_x_ebis_off->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
+			  lume_E_vs_x_ebis_det[det_id]->Fill( lume_evt->GetX(),lume_evt->GetBE(),-1.* react->GetEBISFillRatio() );
+			  lume_E_vs_x_ebis_off_det[det_id]->Fill( lume_evt->GetX(),lume_evt->GetBE(),1. );
+			} // ebis
+		}
+
 		// Progress bar
 		bool update_progress = false;
 		if( n_entries < 200 )

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1332,6 +1332,7 @@ void ISSHistogrammer::ResetHists() {
 	ebis_td_recoil->Reset("ICESM");
 	ebis_td_array->Reset("ICESM");
 	ebis_td_elum->Reset("ICESM");
+	ebis_td_lume->Reset("ICESM");
 	t1_td_recoil->Reset("ICESM");
 	sc_td_recoil->Reset("ICESM");
 	recoil_array_tw_hit0->Reset("ICESM");
@@ -1753,6 +1754,28 @@ void ISSHistogrammer::ResetHists() {
 	elum_recoil_random->Reset("ICESM");
 	elum_recoilT_random->Reset("ICESM");
 	elum_vs_T1->Reset("ICESM");
+
+	//LUME (All vectors have the same size.)
+	for ( unsigned int i = 0; i < lume_det.size(); ++i ) {
+		lume_det[i]->Reset("ICESM");
+		lume_ebis_det[i]->Reset("ICESM");
+		lume_ebis_on_det[i]->Reset("ICESM");
+		lume_ebis_off_det[i]->Reset("ICESM");
+		lume_E_vs_x_det[i]->Reset("ICESM");
+		lume_E_vs_x_ebis_det[i]->Reset("ICESM");
+		lume_E_vs_x_ebis_on_det[i]->Reset("ICESM");
+		lume_E_vs_x_ebis_off_det[i]->Reset("ICESM");
+	}
+
+	lume->Reset("ICESM");
+	lume_E_vs_x->Reset("ICESM");
+	lume_ebis->Reset("ICESM");
+	lume_ebis_on->Reset("ICESM");
+	lume_ebis_off->Reset("ICESM");
+	lume_vs_T1->Reset("ICESM");
+	lume_E_vs_x_ebis->Reset("ICESM");
+	lume_E_vs_x_ebis_on->Reset("ICESM");
+	lume_E_vs_x_ebis_off->Reset("ICESM");
 
 	return;
 	


### PR DESCRIPTION
This request makes a couple of small tweaks in the event builder, namely giving a channel zero instead of NaN if the back channel is above threshold and it stores the position in a variable so it only needs to be calculated one time. Some small changes to the _events.root histograms so the axes have labels in keV as well.

The largest addition is histograms in the *_hists.root files where different LUME histograms have been added, e.g. E vs x gated on and off EBIS and plots for individual detectors.