### PR TITLE
Fix for issue #91

### DIFF
--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -2691,6 +2691,9 @@ void ISSEventBuilder::CdFinder() {
 
 	//std::cout << __PRETTY_FUNCTION__ << std::endl;
 
+	// Quick check that we have a CD at all
+	if( set->GetNumberOfCDLayers() == 0 ) return;
+
 	// Multiplicity matrix
 	for( unsigned int i = 0; i < set->GetNumberOfCDLayers(); ++i )
 		if( cdren_list[i].size() || cdsen_list[i].size() )

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -487,32 +487,32 @@ void ISSSettings::ReadSettings() {
 	cd_erest_stop  = config->GetValue( "CDEnergyRestStop", 1 );
 	cd_etot_start  = config->GetValue( "CDEnergyTotalStart", 0 );
 	cd_etot_stop   = config->GetValue( "CDEnergyTotalStop", 1 );
-	if( cd_eloss_start >= n_cd_layer ){
+	if( cd_eloss_start >= n_cd_layer && n_cd_layer != 0 ){
 		std::cerr << "CDEnergyLossStart must be less than NumberOfRecoilLayers" << std::endl;
 		std::cerr << "Reverting CDEnergyLossStart to default value of 0" << std::endl;
 		cd_eloss_start = 0;
 	}
-	if( cd_eloss_stop >= n_cd_layer ){
+	if( cd_eloss_stop >= n_cd_layer && n_cd_layer != 0 ){
 		std::cerr << "CDEnergyLossStop must be less than NumberOfRecoilLayers" << std::endl;
 		std::cerr << "Reverting CDEnergyLossStop to default value of 0" << std::endl;
 		cd_eloss_stop = 0;
 	}
-	if( cd_erest_start >= n_cd_layer ){
+	if( cd_erest_start >= n_cd_layer && n_cd_layer != 0 ){
 		std::cerr << "CDEnergyRestStart must be less than NumberOfRecoilLayers" << std::endl;
 		std::cerr << "Reverting CDEnergyRestStart to default value of 1" << std::endl;
 		cd_erest_start = 1;
 	}
-	if( cd_erest_stop >= n_cd_layer ){
+	if( cd_erest_stop >= n_cd_layer && n_cd_layer != 0 ){
 		std::cerr << "CDEnergyRestStop must be less than NumberOfRecoilLayers" << std::endl;
 		std::cerr << "Reverting CDEnergyRestStop to default value of 1" << std::endl;
 		cd_erest_stop = 1;
 	}
-	if( cd_etot_start >= n_cd_layer ){
+	if( cd_etot_start >= n_cd_layer && n_cd_layer != 0 ){
 		std::cerr << "CDEnergyTotalStart must be less than NumberOfRecoilLayers" << std::endl;
 		std::cerr << "Reverting CDEnergyTotalStart to default value of 0" << std::endl;
 		cd_etot_start = 0;
 	}
-	if( cd_etot_stop >= n_cd_layer ){
+	if( cd_etot_stop >= n_cd_layer && n_cd_layer != 0 ){
 		std::cerr << "CDEnergyTotalStop must be less than NumberOfRecoilLayers" << std::endl;
 		std::cerr << "Reverting CDEnergyTotalStop to default value of 1" << std::endl;
 		cd_etot_stop = 1;


### PR DESCRIPTION
This is a fix for issue #91 caused by the CdFinder algorithm trying to access the dE layer of the CD detector when the user declares that there are no layers!

Solution is to instantly return from CdFinder() if there GetNumberOfCDLayers() == 0...

Might be a more elegant way generally of calling or returning from the particle reconstruction algorithms if we have no events or detectors in place. But for now, fix it like this.