### PR TITLE
Fix for CD in eventbuilder

### DIFF
--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -769,7 +769,8 @@ unsigned long ISSEventBuilder::BuildEvents() {
 				mysector = set->GetCDSector( myvme, mymod, mych );
 
 				// Ring side
-				if( myring >= 0 && mylayer >= 0 && mylayer < set->GetNumberOfCDLayers() ) {
+				if( myring < set->GetNumberOfCDRings() &&
+					mylayer < set->GetNumberOfCDLayers() ) {
 
 					cdren_list[mylayer].push_back( myenergy );
 					cdrtd_list[mylayer].push_back( mytime );
@@ -780,7 +781,8 @@ unsigned long ISSEventBuilder::BuildEvents() {
 				}
 
 				// Sector side
-				if( mysector >= 0 && mylayer >= 0 && mylayer < set->GetNumberOfCDLayers() ) {
+				if( mysector < set->GetNumberOfCDSectors() &&
+					mylayer < set->GetNumberOfCDLayers() ) {
 
 					cdsen_list[mylayer].push_back( myenergy );
 					cdstd_list[mylayer].push_back( mytime );

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -390,6 +390,12 @@ void ISSEventBuilder::Initialise(){
 	std::vector<char>().swap(lne_id_list);
 	std::vector<char>().swap(lfe_id_list);
 
+	cdren_list.clear();
+	cdrtd_list.clear();
+	cdrid_list.clear();
+	cdsen_list.clear();
+	cdstd_list.clear();
+	cdsid_list.clear();
 	cdren_list.resize( set->GetNumberOfCDLayers(), std::vector<float>() );
 	cdrtd_list.resize( set->GetNumberOfCDLayers(), std::vector<double>() );
 	cdrid_list.resize( set->GetNumberOfCDLayers(), std::vector<char>() );

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -571,10 +571,9 @@ void ISSSettings::ReadSettings() {
 					mm++;
 					cc -= GetMaximumNumberOfVmeChannels();
 				}
-				cd_vme[i][j][k] = (int)config->GetValue( Form( "CD_%d_%d.%s.Crate", i, j, sidechar.data() ), (int)1 ); // layer, ring
-				cd_mod[i][j][k] = (int)config->GetValue( Form( "CD_%d_%d.%s.Module", i, j, sidechar.data() ), (int)mm );
-				cd_ch[i][j][k] = (int)config->GetValue( Form( "CD_%d_%d.%s.Channel", i, j, sidechar.data() ), (int)cc );
-
+				cd_vme[i][j][k] = (int)config->GetValue( Form( "CD_%d_%d.%s.Crate", i, k, sidechar.data() ), (int)1 ); // layer, ring
+				cd_mod[i][j][k] = (int)config->GetValue( Form( "CD_%d_%d.%s.Module", i, k, sidechar.data() ), (int)mm );
+				cd_ch[i][j][k] = (int)config->GetValue( Form( "CD_%d_%d.%s.Channel", i, k, sidechar.data() ), (int)cc );
 				if( cd_vme[i][j][k] < GetNumberOfVmeCrates() &&
 				   cd_mod[i][j][k] < GetMaximumNumberOfVmeModules() &&
 				   cd_ch[i][j][k] < GetMaximumNumberOfVmeChannels() ) {


### PR DESCRIPTION
Fix where two if statements which checked if unsigned variables where positive (always true).

Fixed an issue where CD vectors where not completely emptied after each event.

Fix where config->GetValue for CD detectors looked at side instead of channel number.