### PR TITLE
Add an ebis flag for sorting

### DIFF
--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -72,6 +72,15 @@ public:
 	void FinishMesytecData();
 	void GetVMEChanID();
 
+	inline void EBISOnly(){ flag_ebis = true; };
+	inline bool EBISWindow( long long int t ){
+		if( ebis_period == 0 ) return false;
+		else {
+			long long test_t = ( t - ebis_tm_stp ) % ebis_period;
+			return ( test_t < 4000000 && test_t > 0 );
+		}
+	};
+
 	void SetOutput( std::string output_file_name );
 
 	inline void CloseOutput(){
@@ -154,8 +163,8 @@ private:
 	};
 
 
-	// Flag for source run
-	bool flag_source;
+	// Flags for source or EBIS run
+	bool flag_source, flag_ebis;
 
 	// Logs
 	std::stringstream sslogs;
@@ -213,6 +222,9 @@ private:
 	UInt_t header_DataLen; // 4 byte.
 
 	// Interpretated variables
+	long long ebis_tm_stp = 0;
+	unsigned int ebis_period = 0;
+	unsigned int ebis_first = 0;
 	unsigned long long my_tm_stp;
 	unsigned long my_tm_stp_lsb;
 	unsigned long my_tm_stp_msb;

--- a/iss_sort.cc
+++ b/iss_sort.cc
@@ -388,6 +388,7 @@ void do_convert(){
 	conv.AddSettings( myset );
 	conv.AddCalibration( mycal );
 	if( flag_source ) conv.SourceOnly();
+	if( flag_ebis ) conv.EBISOnly();
 	std::cout << "\n +++ ISS Analysis:: processing Converter +++" << std::endl;
 
 	TFile *rtest;

--- a/iss_sort.cc
+++ b/iss_sort.cc
@@ -82,6 +82,8 @@ bool flag_autocal = false;
 bool flag_data = false;
 bool flag_pace4 = false;
 bool flag_nptool = false;
+bool flag_ebis = false;
+
 
 // select what steps of the analysis to be forced
 std::vector<bool> force_convert;
@@ -169,6 +171,7 @@ void* monitor_run( void* ptr ){
 	conv_mon = std::make_shared<ISSConverter>();
 	conv_mon->AddSettings( calfiles->myset );
 	conv_mon->AddCalibration( calfiles->mycal );
+	if( flag_ebis ) conv_mon->EBISOnly();
 
 	// Setup the event builder step
 	eb_mon = std::make_shared<ISSEventBuilder>();
@@ -838,6 +841,7 @@ int main( int argc, char *argv[] ){
 	interface->Add("-r", "Reaction file", &name_react_file );
 	interface->Add("-nptool", "Flag for NPTool simulation input", &flag_nptool );
 	interface->Add("-pace4", "Flag for PACE4 particle input", &flag_pace4 );
+	interface->Add("-ebis", "Flag to define an EBIS only run, discarding data >4ms after an EBIS event", &flag_ebis );
 	interface->Add("-f", "Flag to force new ROOT conversion", &flag_convert );
 	interface->Add("-e", "Flag to force new event builder (new calibration)", &flag_events );
 	interface->Add("-source", "Flag to define an source only run", &flag_source );

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -1387,7 +1387,6 @@ void ISSConverter::FinishCAENData(){
 
 			ebis_tm_stp = caen_data->GetTime();
 
-
 		}
 
 		else if( caen_data->GetModule() == set->GetT1Module() &&

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -2,8 +2,9 @@
 
 ISSConverter::ISSConverter() {
 
-	// Default that we do not have a source only run
+	// Default that we do not have a source only run or EBIS run
 	flag_source = false;
+	flag_ebis = false;
 
 	// No progress bar by default
 	_prog_ = false;
@@ -1129,11 +1130,17 @@ void ISSConverter::ProcessASICData(){
 			asic_data->SetThreshold( true );
 		else asic_data->SetThreshold( false );
 
+		
 		// Set this data and fill event to tree
-		data_packet->SetData( asic_data );
-		if( !flag_source ) output_tree->Fill();
-		asic_data->Clear();
-		data_packet->ClearData();
+		// only if we are in the EBIS window, if the flag is set by the user
+		if( !flag_ebis || EBISWindow( asic_data->GetTime() ) ) {
+
+			data_packet->SetData( asic_data );
+			if( !flag_source ) output_tree->Fill();
+			asic_data->Clear();
+			data_packet->ClearData();
+
+		}
 
 		// Count asic hit per module
 		ctr_asic_hit[my_mod_id]++;
@@ -1367,6 +1374,20 @@ void ISSConverter::FinishCAENData(){
 			//my_info_code = set->GetEBISCode();
 			my_info_code = 21; // CAEN EBIS is always 21 (defined here), Array EBIS is 15
 
+			// Check EBIS time and period from the CAEN copy of the pulse
+			if( ebis_tm_stp != 0 && ebis_period == 0 &&
+			   caen_data->GetTime() > (long long)ebis_tm_stp ){
+
+				ebis_period = caen_data->GetTime() - ebis_tm_stp;
+				ebis_first = ebis_tm_stp;
+				std::cout << "EBIS period detected = " << ebis_period;
+				std::cout << " ns" << std::endl;
+
+			}
+
+			ebis_tm_stp = caen_data->GetTime();
+
+
 		}
 
 		else if( caen_data->GetModule() == set->GetT1Module() &&
@@ -1423,7 +1444,8 @@ void ISSConverter::FinishCAENData(){
 		}
 
 		// Otherwise it is real data, so fill a caen event
-		else {
+		// only if we are in the EBIS window, if the flag is set by the user
+		else if( !flag_ebis || EBISWindow( caen_data->GetTime() ) ) {
 
 			// Set this data and fill event to tree
 			// Also add the time offset when we do this
@@ -1653,10 +1675,15 @@ void ISSConverter::FinishMesytecData(){
 
 			// Set this data and fill event to tree
 			// Also add the time offset when we do this
-			mesy_data->SetTimeStamp( mesy_data->GetTime() + cal->MesytecTime( mesy_data->GetModule(), mesy_data->GetChannel() ) );
-			data_packet->SetData( mesy_data );
-			if( !flag_source ) output_tree->Fill();
-			data_packet->ClearData();
+			// only if we are in the EBIS window, if the flag is set by the user
+			if( !flag_ebis || EBISWindow( mesy_data->GetTime() ) ) {
+
+				mesy_data->SetTimeStamp( mesy_data->GetTime() + cal->MesytecTime( mesy_data->GetModule(), mesy_data->GetChannel() ) );
+				data_packet->SetData( mesy_data );
+				if( !flag_source ) output_tree->Fill();
+				data_packet->ClearData();
+
+			}
 
 		} // adc item
 


### PR DESCRIPTION
This is inspired by Miniball, where a flag is used in the sorting to speed things up by taking events only within a 4 µs time window after the EBIS. The throws away a lot of background gammas at Miniball and speeds up the data sorting. Here is might throw away some noise events to help things.

To be used online only, a full sort should be done offline after the beam time to make sure no events get missed in this process.