### PR TITLE
Tcutg txt

### DIFF
--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -181,6 +181,8 @@ public:
 	void AddBindingEnergy( short Ai, short Zi, TString ame_be_str );///< Add a binding energy to the ame_be mass-table map
 	std::shared_ptr<TCutG> ReadCutFile( std::string cut_filename,
 										std::string cut_name );
+    int ReadCoordinates( std::string line, double *x, double *y ); ///< Used by CreateTCutG
+    std::shared_ptr<TCutG> CreateTCutG( std::ifstream *cut_file, std::string cut_name );
 	void ReadMassTables();///< Reads the AME2020 mass tables
 	void ReadReaction();///< Reads the reaction input file
 

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -359,6 +359,84 @@ std::shared_ptr<TCutG> ISSReaction::ReadCutFile( std::string cut_filename,
   return cut;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Read coordinate pairs from a string. First removes any comments after a #.
+/// Returns 0 if the string is empty (including whitespace).
+/// Returns 1 on success.
+/// Returns 2 if the conversion fails.
+int ISSReaction::ReadCoordinates( std::string line, double *x, double *y )
+{
+  int n_conversions;
+  int index = -1;
+  double x_temp, y_temp;
+
+  // Remove any comments beginning with #.
+  line.erase( std::find( line.begin(), line.end(), '#' ), line.end() );
+
+  // Check if line is empty (including whitespace).
+  int n = sscanf(line.c_str(), " %n", &index);
+  if( n == 0 &&               /* No successful conversions. */
+      index != -1 &&          /* %n was reached, so index no longer -1. */
+      line[index] == '\0')    /* String actually ends at the format string end. */
+    return 0; // Nothing to convert.
+
+  index = -1;
+  n_conversions = sscanf(line.c_str(), "%lf %lf %n", &x_temp, &y_temp, &index);
+  if( n_conversions == 2 &&   /* Two successful conversions. */
+      index !=-1 &&           /* %n was reached, so index no longer -1. */
+      line[index] == '\0')    /* String actually ends at the format string end. */
+    {
+
+      *x = x_temp; // Only store the x y pair if conversion was successful.
+      *y = y_temp;
+      return 1;    // Successfully converted two doubles.
+
+    }
+
+  return 2; // Failed to convert string.
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Creates a TCutG object by reading coordinate pairs from a text file.
+/// Each line should consist of x y coordinates with space as a delimiter.
+std::shared_ptr<TCutG> ISSReaction::CreateTCutG( std::ifstream *cut_file,
+												 std::string cut_name ) {
+
+  std::shared_ptr<TCutG> cut;
+  std::vector<double> x_vector, y_vector;
+  int counter = 0;
+  std::string line;
+
+  // Read file line by line.
+  while( getline(*cut_file,line) )
+    {
+
+      int converted;
+      double x,y;
+      converted = ReadCoordinates(line, &x, &y);
+      if( !converted )
+		continue; // Line is empty (or is a comment).
+
+      if( converted == 2 ) {
+		std::cerr << "Could not process data on line " <<
+		  counter << " for " << cut_name << std::endl;
+		return std::make_shared<TCutG>();
+      }
+
+      x_vector.push_back(x);
+      y_vector.push_back(y);
+	  counter++;
+    }
+
+  cut = std::make_shared<TCutG>( TCutG( cut_name.data(), counter ) );
+  cut->SetVarX( "x" );
+  cut->SetVarY( "y" );
+  for( int i = 0; i < counter; i++ )
+	cut->SetPoint( i, x_vector[i], y_vector[i] );
+
+  return cut;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 /// Stores the binding energies per nucleon for each nucleus from the AME
 /// 2020 file


### PR DESCRIPTION
Made it possible to give ISSSort a text file for TCuts as an option to a ROOT file. 
If the file provided is not a root file, it treats it as a text file instead. 

A new function, CreateTCutG then tries to create a TCutG object from the text file.
A help function ReadCoordinates tries to extract an x y-pair and checks that there 
is nothing else (except for comments).

If the file contains something else apart from x y and comments, CreateTCutG returns 
an empty TCut and displays a message.

The following lines in a text file gives the cut for
the attached figure.[
![textfile_cut](https://github.com/user-attachments/assets/ea0b90cd-e711-4119-b551-7569f1bdd771)
](url) 

`# This file is a cut for the fission fragment dE-E.`
`# The bottom row is:`
`     `
`    0 8000 # Can start a line with whitespace for alignment.`
`           # and have multiple spaces bewteen a pair.`
`20000 3000`
`50000 2000`
``
`# The top row:`
`50000    2200 # Can have multiple whitespaces bewteen x and y.`
`20000 3600`
`    0 8200`

`    0 8000 # Don't forget to close the polygon.`

