### PR TITLE
Compile with -O3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CXX          = $(shell root-config --cxx)
 CC           = $(shell root-config --cc)
 
 # Flags for compiler.
-CPPFLAGS	 = -c -Wall -Wextra $(ROOTCPPFLAGS) -g -fPIC
+CPPFLAGS	 = -c -Wall -Wextra $(ROOTCPPFLAGS) -g -fPIC -O3
 CPPFLAGS	+= -DUNIX -DPOSIX $(OSDEF)
 INCLUDES	+= -I$(INC_DIR) -I.
 


### PR DESCRIPTION
Speedup ~ 20 %.  No difference in text output.

```
f96hajo@subfy05:~/2025/22Ne25$ time ../../q/ISSSort/bin/iss_sort -s ../calibrations/settings_stable_beam2025.dat -c ../calibrations/calibration_stable_beam2025.dat -r ../calibrations/reaction_stable_beam2025.dat -i /chalmers/groups/subexp/iss/2025/22Ne25/R69_0 -f -e -d sorted -ebis > out_orig.txt

real    1m25.763s
user    1m18.796s
sys     0m2.400s
f96hajo@subfy05:~/2025/22Ne25$ time ../../q/ISSSort/bin/iss_sort -s ../calibrations/settings_stable_beam2025.dat -c ../calibrations/calibration_stable_beam2025.dat -r ../calibrations/reaction_stable_beam2025.dat -i /chalmers/groups/subexp/iss/2025/22Ne25/R69_0 -f -e -d sorted -ebis > out_-O3.txt

real    1m9.335s
user    1m2.192s
sys     0m2.399s
f96hajo@subfy05:~/2025/22Ne25$ diff -u out_orig.txt out_-O3.txt
f96hajo@subfy05:~/2025/22Ne25$ 
```