### PR TITLE
Fix ebis flag.

### DIFF
--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -76,7 +76,9 @@ public:
 	inline bool EBISWindow( long long int t ){
 		if( ebis_period == 0 ) return false;
 		else {
-			long long test_t = ( t - ebis_tm_stp ) % ebis_period;
+			// Note: (a % b) is not in range 0..b-1 for negative a.
+			long long test_t = ((( t - ebis_tm_stp ) % ebis_period) +
+								ebis_period) % ebis_period;
 			return ( test_t < 4000000 && test_t > 0 );
 		}
 	};


### PR DESCRIPTION
% is a remainder operator (apparently), and give negative output for negative input. Fix by adding and then doing % again.

Sorry for slowing down the ebis flag so much by getting more statistics :-)

Found while attempting to speed up data sorting by presorting the file.  That found ~ 3 times as many hits within ebis flag cut for R69_0:
```
f96hajo@subfy05:~/2025/22Ne25$ diff out_orig.txt out_modfix.txt -u
--- out_orig.txt        2025-06-26 20:09:40.156513457 +0200
+++ out_modfix.txt      2025-06-26 20:28:10.770062295 +0200
@@ -18,50 +18,50 @@
EBIS period detected = 49999120 ns
      100%%
  Building time-ordered index of events...
- Sorting: size of the sorted index = 4663451
    100%        
+ Sorting: size of the sorted index = 13683409
    100%        
  Writing data and closing the file
 
  +++ ISS Analysis:: processing EventBuilder +++
 sorted/R69_0.root --> sorted/R69_0_events.root
- Event Building: number of entries in input tree = 4663451
+ Event Building: number of entries in input tree = 13683409
  Event Building: using raw timestamp for event ordering
    100%        
    100%        
  ISSEventBuilder finished...
-  ASIC data packets = 28625
+  ASIC data packets = 419914
    Module 0 pause = 0
            resume = 0
         dead time = 0 s
-        live time = 1012.08 s
+        live time = 1026.83 s
    Module 1 pause = 0
            resume = 0
         dead time = 0 s
-        live time = 994.332 s
+        live time = 1009.48 s
    Module 2 pause = 0
            resume = 0
         dead time = 0 s
-        live time = 997.433 s
+        live time = 1013.13 s
   CAEN data packets = 39327
    Module 0 live time = 413.891 s
    Module 1 live time = 1013.63 s
-  Mesytec data packets = 224413
-   Module 0 live time = 1010.83 s
+  Mesytec data packets = 8853082
+   Module 0 live time = 1013.68 s
    Module 1 live time = 0 s
-   Module 2 live time = 1010.83 s
-   Module 3 live time = 1010.83 s
-   Module 4 live time = 1010.83 s
-   Module 5 live time = 1010.83 s
-   Module 6 live time = 1010.83 s
+   Module 2 live time = 1013.68 s
+   Module 3 live time = 1013.68 s
+   Module 4 live time = 1013.68 s
+   Module 5 live time = 1013.68 s
+   Module 6 live time = 1013.68 s
   Info data packets = 4371086
-   Array p/n-side correlated events = 3365
-   Array p-side only events = 4632
+   Array p/n-side correlated events = 48194
+   Array p-side only events = 68955
    Recoil events = 0
    MWPC events = 0
    ELUM events = 0
    ZeroDegree events = 0
-   Gamma-ray events = 95880
-   LUME events = 1486
-   CD events = 14952
+   Gamma-ray events = 3775685
+   LUME events = 58958
+   CD events = 592069
    CAEN pulser = 202784
    Mesytec pulser
     Module 0 = 405568
@@ -83,13 +83,13 @@
    T1 events = 0
    SC events = 26
    Laser events = 0
-  Tree entries = 57605
+  Tree entries = 2120426
 Writing output file... Done!
 
 
  +++ ISS Analysis:: processing Histogrammer +++
- ISSHistogrammer: number of entries in event tree = 57605
+ ISSHistogrammer: number of entries in event tree = 2120426
  ISSHistogrammer: Start filling histograms
    100%       
    100%        
 
 Finished!
```
While the difference to a presorted file is small (and likely due to getting a few more hits at the beginning):
```
f96hajo@subfy05:~/2025/22Ne25$ diff out_modfix.txt out_resort_modfix.txt -u
--- out_modfix.txt      2025-06-26 20:28:10.770062295 +0200
+++ out_resort_modfix.txt       2025-06-26 21:01:50.714249974 +0200
@@ -9,30 +9,30 @@
 Beam energy at centre of target = 130.342 MeV
 
  +++ ISS Analysis:: processing Converter +++
-/chalmers/groups/subexp/iss/2025/22Ne25/R69_0 --> sorted/R69_0.root
-Converting file: /chalmers/groups/subexp/iss/2025/22Ne25/R69_0 from block 0
-        File size = 524288000
+R69_0_resort --> sorted/R69_0_resort.root
+Converting file: R69_0_resort from block 0
+        File size = 492830720
        Block size = 65536
-         N blocks = 8000
+         N blocks = 7520
 
EBIS period detected = 49999120 ns
      100%%
EBIS period detected = 49999120 ns
      100%%
  Building time-ordered index of events...
- Sorting: size of the sorted index = 13683409
    100%        
+ Sorting: size of the sorted index = 13681451
    100%        
  Writing data and closing the file
 
  +++ ISS Analysis:: processing EventBuilder +++
-sorted/R69_0.root --> sorted/R69_0_events.root
- Event Building: number of entries in input tree = 13683409
+sorted/R69_0_resort.root --> sorted/R69_0_resort_events.root
+ Event Building: number of entries in input tree = 13681451
  Event Building: using raw timestamp for event ordering
    100%        
    100%        
  ISSEventBuilder finished...
-  ASIC data packets = 419914
+  ASIC data packets = 417953
    Module 0 pause = 0
            resume = 0
         dead time = 0 s
-        live time = 1026.83 s
+        live time = 1014.93 s
    Module 1 pause = 0
            resume = 0
         dead time = 0 s
@@ -40,11 +40,11 @@
    Module 2 pause = 0
            resume = 0
         dead time = 0 s
-        live time = 1013.13 s
-  CAEN data packets = 39327
+        live time = 1010.03 s
+  CAEN data packets = 39329
    Module 0 live time = 413.891 s
-   Module 1 live time = 1013.63 s
-  Mesytec data packets = 8853082
+   Module 1 live time = 1013.68 s
+  Mesytec data packets = 8853083
    Module 0 live time = 1013.68 s
    Module 1 live time = 0 s
    Module 2 live time = 1013.68 s
@@ -53,15 +53,15 @@
    Module 5 live time = 1013.68 s
    Module 6 live time = 1013.68 s
   Info data packets = 4371086
-   Array p/n-side correlated events = 48194
-   Array p-side only events = 68955
+   Array p/n-side correlated events = 47962
+   Array p-side only events = 68625
    Recoil events = 0
    MWPC events = 0
    ELUM events = 0
    ZeroDegree events = 0
-   Gamma-ray events = 3775685
+   Gamma-ray events = 3775686
    LUME events = 58958
-   CD events = 592069
+   CD events = 592011
    CAEN pulser = 202784
    Mesytec pulser
     Module 0 = 405568
@@ -83,13 +83,13 @@
    T1 events = 0
    SC events = 26
    Laser events = 0
-  Tree entries = 2120426
+  Tree entries = 2120116
 Writing output file... Done!
 
 
  +++ ISS Analysis:: processing Histogrammer +++
- ISSHistogrammer: number of entries in event tree = 2120426
+ ISSHistogrammer: number of entries in event tree = 2120116
  ISSHistogrammer: Start filling histograms
    100%        
    100%        
 
 Finished!
```

The presorting did however *not* improve the execution time!  Actually 4 min 30 s became 4 min 40 s....