### PR TITLE
Set compression level to analysis (LZ4).

### DIFF
--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -56,6 +56,7 @@ void ISSConverter::SetOutput( std::string output_file_name ){
 	// Open output file
 	output_file = new TFile( output_file_name.data(), "recreate" );
 	//if( !flag_source ) output_file->SetCompressionLevel(0);
+	output_file->SetCompressionSettings(ROOT::RCompressionSetting::EDefaults::kUseAnalysis);
 
 	return;
 

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -327,6 +327,7 @@ void ISSEventBuilder::SetOutput( std::string output_file_name ) {
 	// Create output file and create events tree
 	// --------------------------------------------------------- //
 	output_file = new TFile( output_file_name.data(), "recreate" );
+	output_file->SetCompressionSettings(ROOT::RCompressionSetting::EDefaults::kUseAnalysis);
 	output_tree = new TTree( "evt_tree", "evt_tree" );
 	output_tree->Branch( "ISSEvts", write_evts.get() );
 	output_tree->SetAutoFlush();

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -36,6 +36,7 @@ void ISSHistogrammer::SetOutput( std::string output_file_name ){
 	// Create output file and create reaction tree
 	// --------------------------------------------------------- //
 	output_file = new TFile( output_file_name.data(), "recreate" );
+	output_file->SetCompressionSettings(ROOT::RCompressionSetting::EDefaults::kUseAnalysis);
 	output_tree = new TTree( "rxtree", "Reaction data tree" );
 	output_tree->Branch( "RxEvent", rx_evts.get() );
 	output_tree->Branch( "RxInfo", rx_info.get() );


### PR DESCRIPTION
Default seems to be zlib.  For smaller files, one might want to try 

This was not as big a win as I would have hoped:

```
old:
real    1m4,279s
user    0m54,924s
sys     0m2,138s

new (kUseAnalysis):
real    1m1,991s
user    0m50,480s
sys     0m2,087s

other (kUseGeneralPurpose)
real    1m2,288s
user    0m53,618s
sys     0m2,055s
```

It trades speed for file size:

```
old:
-rw-r----- 1 f96hajo f96hajo 289259687 30 jun 04.28 R69_0.root
-rw-r----- 1 f96hajo f96hajo 175381347 30 jun 04.28 R69_0_events.root
-rw-r----- 1 f96hajo f96hajo      1445 30 jun 04.28 R69_0_events.log
-rw-r----- 1 f96hajo f96hajo  35727949 30 jun 04.28 R69_0_hists.root

new (kUseAnalysis):
-rw-r----- 1 f96hajo f96hajo 309561887 30 jun 04.22 R69_0.root
-rw-r----- 1 f96hajo f96hajo 330499708 30 jun 04.23 R69_0_events.root
-rw-r----- 1 f96hajo f96hajo      1445 30 jun 04.23 R69_0_events.log
-rw-r----- 1 f96hajo f96hajo  33897605 30 jun 04.23 R69_0_hists.root

other (kUseGeneralPurpose)
-rw-r----- 1 f96hajo f96hajo 240991275 30 jun 04.36 R69_0.root
-rw-r----- 1 f96hajo f96hajo 200734560 30 jun 04.36 R69_0_events.root
-rw-r----- 1 f96hajo f96hajo      2890 30 jun 04.36 R69_0_events.log
-rw-r----- 1 f96hajo f96hajo  11622583 30 jun 04.36 R69_0_hists.root
```

I'm running this on an NFS machine, so may be hampered by that.  Perhaps you get different results.
I.e. putting this up more for testing than directly advocating it.