### PR TITLE
Clarify that PHC correction is for an enhanced pulse height with increasing Z.

### DIFF
--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -49,8 +49,8 @@ const double p_mass  = 938272.08816;	///< mass of the proton in keV/c^2
 const double n_mass  = 939565.42052;	///< mass of the neutron in keV/c^2
 const double u_mass  = 931494.10242;	///< atomic mass unit in keV/c^2
 const double T_to_mm =   299.792458;	///< in units of 1/mm
-const double k_Si 	 =     2.88e-10;	///< k value - mm/e-h pair for PHD in silicon
-const double e0_Si 	 =     3.67e-03;	///< epsilon_0 for silicon for PHD in keV
+const double k_Si 	 =     2.88e-10;	///< k value - mm/e-h pair for PHC in silicon
+const double e0_Si 	 =     3.67e-03;	///< epsilon_0 for silicon for PHC in keV
 
 // Element names
 const std::vector<std::string> gElName = {

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -1269,6 +1269,8 @@ void ISSReaction::CalculatePulseHeightCorrection( std::string isotope ) {
 		dEdx_n = GetNuclearEnergyLoss( E, range, gStopping[4], gStopping[5] );
 
 		// From W. N. Lennard et al. NIM A248 (1986) 454
+		// "Nonlinear response of Si detectors for low-Z ions"
+		// (Enhanced pulse height with increasing Z.)
 		double PHC = e0_Si - k_Si * dEdx_e;
 		PHC = e0_Si / PHC;
 		Edet += dE * PHC;


### PR DESCRIPTION
To be clearer that the correction is not for a (decreased) pulse height due to, e.g. plasma recombination at high(er) Z.

@Liam: Have you seen any formula for the latter?  That would be so useful...
